### PR TITLE
Migrate from qiskit-aqua to modern Qiskit stack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.2.0
+  win: circleci/windows@5.0
 
 jobs:
   test-linux:
@@ -10,7 +10,7 @@ jobs:
         type: string
 
     docker:
-      - image: circleci/python:<< parameters.python-image-version >>
+      - image: cimg/python:<< parameters.python-image-version >>
 
     steps:
       - checkout
@@ -49,7 +49,7 @@ jobs:
         type: string
 
     macos:
-      xcode: "12.2.0"
+      xcode: "15.4.0"
 
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -63,7 +63,7 @@ jobs:
             brew install pyenv
 
       - restore_cache: &restore-cache-pyenv
-          key: v1-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-12.2.0
+          key: v1-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-15.4.0
 
       - run:
           name: Install python
@@ -77,7 +77,7 @@ jobs:
             echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
 
       - save_cache: &save-cache-pyenv
-          key: v1-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-12.2.0
+          key: v1-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-15.4.0
           paths:
             - ~/.pyenv
 
@@ -128,7 +128,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.12
 
     steps:
       - checkout
@@ -160,15 +160,15 @@ workflows:
       - test-linux:
           matrix:
             parameters:
-              python-image-version: ["3.6", "3.7", "3.8"]
+              python-image-version: ["3.10", "3.11", "3.12", "3.13"]
       - test-osx:
           matrix:
             parameters:
-              python-version: ["3.6.8", "3.7.5", "3.8.6"]
+              python-version: ["3.10.14", "3.11.10", "3.12.8", "3.13.5"]
       - test-win:
           matrix:
             parameters:
-              python-version: ["3.6.8", "3.7.5", "3.8.6"]
+              python-version: ["3.10.11", "3.11.9", "3.12.10", "3.13.5"]
 
   deploy:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,31 @@
 version: 2.1
 
+parameters:
+  cache-generation:
+    type: integer
+    default: 2
+
 orbs:
   win: circleci/windows@5.0
 
 jobs:
   test-linux:
     parameters:
-      python-image-version:
+      python-version:
         type: string
 
     docker:
-      - image: cimg/python:<< parameters.python-image-version >>
+      - image: python:<< parameters.python-version >>
 
     steps:
       - checkout
 
+      - run: &save-python-version
+          name: Save full python version in file to be used as part of cache key
+          command: python -V > /tmp/python-V.txt
+
       - restore_cache: &restore-cache-env
-          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
+          key: &env-cache-key v<< pipeline.parameters.cache-generation >>-python-{{ checksum "/tmp/python-V.txt" }}-pip-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
 
       - run: &create-venv-install-deps
           name: Create virtual environment and install dependencies
@@ -27,7 +36,7 @@ jobs:
             pip install -r requirements.txt -r tests/requirements.txt
 
       - save_cache: &save-cache-env
-          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
+          key: *env-cache-key
           paths:
             - env
 
@@ -43,43 +52,49 @@ jobs:
             . env/bin/activate
             codecov
 
-  test-osx:
+  test-macos:
     parameters:
       python-version:
         type: string
+      xcode:
+        type: string
+        default: "16.4.0"
 
     macos:
-      xcode: "15.4.0"
-
-    environment:
-      HOMEBREW_NO_AUTO_UPDATE: 1
+      xcode: << parameters.xcode >>
 
     steps:
       - checkout
 
-      - run:
+      - restore_cache: &restore-cache-pyenv
+          key: &brew-pyenv-cache-key v<< pipeline.parameters.cache-generation >>-brew-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-<< parameters.xcode >>
+
+      - run: &brew-install-pyenv
           name: Install pyenv
           command: |
+            brew update
             brew install pyenv
 
-      - restore_cache: &restore-cache-pyenv
-          key: v1-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-15.4.0
-
-      - run:
+      - run: &pyenv-install-python
           name: Install python
-          command: |
-            pyenv install << parameters.python-version>> -s
+          command: pyenv install << parameters.python-version >> -s
 
-      - run:
+      - run: &pyenv-set-system-python
           name: Set system python
           command: |
-            pyenv global << parameters.python-version >>
+            echo -e '\n\n# Initialize pyenv' >> ~/.bash_profile
+            echo 'eval "$(pyenv init --path 2>/dev/null || true)"' >> ~/.bash_profile
             echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
+            pyenv global << parameters.python-version >>
 
       - save_cache: &save-cache-pyenv
-          key: v1-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-15.4.0
+          key: *brew-pyenv-cache-key
           paths:
+            - /Users/distiller/Library/Caches/Homebrew
+            - /usr/local/Homebrew
             - ~/.pyenv
+
+      - run: *save-python-version
 
       - restore_cache: *restore-cache-env
 
@@ -91,7 +106,7 @@ jobs:
 
       - run: *run-codecov
 
-  test-win:
+  test-windows:
     parameters:
       python-version:
         type: string
@@ -104,11 +119,25 @@ jobs:
 
       - run:
           name: Install python and create virtualenv
+          shell: bash -eo pipefail
           command: |
-            nuget install python -Version << parameters.python-version >> -ExcludeVersion -OutputDirectory .
-            .\python\tools\python.exe --version
-            .\python\tools\python.exe -m pip install virtualenv
-            .\python\tools\python.exe -m virtualenv env
+            # de-normalize a pre-release version, because why would microsoft follow pep-440?
+            version=$(sed -E 's/([[:digit:]])([[:alpha:]])/\1-\2/' \<<<"<< parameters.python-version >>")
+
+            # resolve python MAJOR.MINOR[.PATCH[-PRERELEASE]] version to the latest
+            # MAJOR.MINOR.PATCH version available on NuGet (ignoring the actual pre-release segment)
+            # note: we rely on versions retrieved being sorted semantically!
+            # (so '3.13' might resolve to '3.13.0rc3' before final release, and to '3.13.0' afterwards)
+            full_version=$(
+              curl -s 'https://azuresearch-usnc.nuget.org/query?q=python&prerelease=true' \
+              | jq -r '.data[] | select(.id == "python") .versions[] | .version' \
+              | awk -F'[.-]' -v ver="$version" \
+                  'index($0, ver) == 1 && $3 >= m { m = $3; v = $0 } END { print v }'
+            )
+
+            nuget install python -Version "$full_version" -ExcludeVersion
+            python/tools/python -V
+            python/tools/python -m venv env
 
       - run:
           name: Install dependencies
@@ -116,8 +145,7 @@ jobs:
             env\Scripts\activate.ps1
             python --version
             pip install -U pip setuptools wheel twine
-            pip install -r requirements.txt
-            pip install -r tests\requirements.txt
+            pip install -U -r requirements.txt -r tests\requirements.txt
 
       - run:
           name: Run unittests
@@ -125,10 +153,9 @@ jobs:
             env\Scripts\activate.ps1
             coverage run -m unittest discover
 
-
   deploy:
     docker:
-      - image: cimg/python:3.12
+      - image: python:3.12
 
     steps:
       - checkout
@@ -160,15 +187,15 @@ workflows:
       - test-linux:
           matrix:
             parameters:
-              python-image-version: ["3.10", "3.11", "3.12", "3.13"]
-      - test-osx:
+              python-version: &python-versions ["3.10", "3.11", "3.12", "3.13", "3.14"]
+      - test-macos:
           matrix:
             parameters:
-              python-version: ["3.10.14", "3.11.10", "3.12.8", "3.13.5"]
-      - test-win:
+              python-version: *python-versions
+      - test-windows:
           matrix:
             parameters:
-              python-version: ["3.10.11", "3.11.9", "3.12.10", "3.13.5"]
+              python-version: *python-versions
 
   deploy:
     jobs:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ full 2^36 state space) produces:
 >>> from qiskit_optimization.minimum_eigensolvers import NumPyMinimumEigensolver
 >>> result = MinimumEigenOptimizer(NumPyMinimumEigensolver()).solve(qp)
 # snipped for brevity
-memory allocation of memory allocation of 1818775484491218187754844912 bytes failed
+memory allocation of 1818775484491218187754844912 bytes failed
 Aborted (core dumped)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # D-Wave Ocean plugin for IBM Qiskit
 
-Enables [Qiskit](https://qiskit.org/) users to obtain ground state(s) of Ising Hamiltonians using [D-Wave](https://www.dwavesys.com/)'s QPU available via [Leap](https://cloud.dwavesys.com/).
+Enables [Qiskit](https://www.ibm.com/quantum/qiskit) users to obtain ground state(s) of Ising Hamiltonians using [D-Wave](https://www.dwavesys.com/)'s QPU available via [Leap](https://cloud.dwavesys.com/).
 
-The package provides an implementation of Qiskit's [`MinimumEigensolver`](https://qiskit.org/documentation/stubs/qiskit.aqua.algorithms.MinimumEigensolver.html)
+The package provides an implementation of Qiskit Optimization's
+[`SamplingMinimumEigensolver`](https://qiskit-community.github.io/qiskit-optimization/apidocs/qiskit_optimization.minimum_eigensolvers.html)
 interface (available as `DWaveMinimumEigensolver`) which can be used directly on qubit operators, or via
-`qikist.optimization`'s [`MinimumEigenOptimizer`](https://qiskit.org/documentation/stubs/qiskit.optimization.algorithms.MinimumEigenOptimizer.html).
+`qiskit_optimization`'s [`MinimumEigenOptimizer`](https://qiskit-community.github.io/qiskit-optimization/stubs/qiskit_optimization.algorithms.MinimumEigenOptimizer.html).
 
 
 ## Examples
 
-Solve a [`QuadraticProgram`](https://qiskit.org/documentation/stubs/qiskit.optimization.QuadraticProgram.html)
-with [`MinimumEigenOptimizer`](https://qiskit.org/documentation/stubs/qiskit.optimization.algorithms.MinimumEigenOptimizer.html)
-(see Qiskit's [tutorial](https://qiskit.org/documentation/tutorials/optimization/3_minimum_eigen_optimizer.html))
+Solve a [`QuadraticProgram`](https://qiskit-community.github.io/qiskit-optimization/stubs/qiskit_optimization.QuadraticProgram.html)
+with [`MinimumEigenOptimizer`](https://qiskit-community.github.io/qiskit-optimization/stubs/qiskit_optimization.algorithms.MinimumEigenOptimizer.html)
 using `DWaveMinimumEigensolver`:
 
 ```python
->>> from qiskit.optimization import QuadraticProgram
->>> from qiskit.optimization.algorithms import MinimumEigenOptimizer
+>>> from qiskit_optimization import QuadraticProgram
+>>> from qiskit_optimization.algorithms import MinimumEigenOptimizer
 >>> from dwave.plugins.qiskit import DWaveMinimumEigensolver
 ...
 >>> # Construct a simple quadratic program
@@ -31,68 +31,62 @@ using `DWaveMinimumEigensolver`:
 >>> result = optimizer.solve(qp)
 ...
 >>> print(result)
-optimal function value: 0.0
-optimal value: [0. 1.]
-status: SUCCESS
->>> result.samples
-[('01', 0.0, 0.39), ('00', 0.0, 0.25), ('10', 0.0, 0.36)]
+fval=0.0, x=0.0, y=0.0, status=SUCCESS
+>>> [(''.join(str(int(v)) for v in s.x), s.fval, s.probability) for s in result.samples]
+[('00', 0.0, 0.33), ('10', 0.0, 0.33), ('01', 0.0, 0.33)]
 ```
 
-Solve a 6-city TSP (or [some other Ising model](https://qiskit.org/documentation/apidoc/qiskit.optimization.applications.ising.html#module-qiskit.optimization.applications.ising)).
+Solve a 6-city TSP (or some other
+[optimization application](https://qiskit-community.github.io/qiskit-optimization/apidocs/qiskit_optimization.applications.html)),
+a 36-qubit Ising Hamiltonian:
 
 ```python
->>> from qiskit.optimization.applications.ising import tsp
->>> from qiskit.optimization.applications.ising.common import sample_most_likely
+>>> from qiskit_optimization.applications import Tsp
+>>> from qiskit_optimization.algorithms import MinimumEigenOptimizer
 >>> from dwave.plugins.qiskit import DWaveMinimumEigensolver
 ...
->>> six_cities_tsp = tsp.random_tsp(6, seed=123)
->>> operator, offset = tsp.get_operator(six_cities_tsp)
-...
->>> print(operator.print_details())
-IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIZ	(-400141.5+0j)
-IIIIIIIIIIIIIIIIIIIIIIIIIIIIZIIIIIII	(-400152.5+0j)
-IIIIIIIIIIIIIIIIIIIIIIIIIIIIZIIIIIIZ	(12+0j)
-# snipped for brevity
->>> print(operator.num_qubits)
-36
+>>> tsp = Tsp.create_random_instance(6, seed=123)
+>>> qp = tsp.to_quadratic_program()
 ...
 >>> dwave_mes = DWaveMinimumEigensolver(num_reads=1000)
->>> result = dwave_mes.compute_minimum_eigenvalue(operator)
+>>> result = MinimumEigenOptimizer(dwave_mes).solve(qp)
 ...
->>> x = sample_most_likely(result.eigenstate)
->>> tsp.tsp_feasible(x)
-True
->>> tsp.get_tsp_solution(x)
-[2, 3, 5, 1, 4, 0]
+>>> tsp.interpret(result)
+[3, 4, 2, 1, 5, 0]
 ```
 
-For comparison, trying this on `NumPyMinimumEigensolver` produces:
+For comparison, trying this on `NumPyMinimumEigensolver` (which constructs the
+full 2^36 state space) produces:
 
 ```python
->>> from qiskit.aqua.algorithms import NumPyMinimumEigensolver
->>> result = NumPyMinimumEigensolver().compute_minimum_eigenvalue(operator)
+>>> from qiskit_optimization.minimum_eigensolvers import NumPyMinimumEigensolver
+>>> result = MinimumEigenOptimizer(NumPyMinimumEigensolver()).solve(qp)
 # snipped for brevity
-MemoryError: Unable to allocate 512. GiB for an array with shape (68719476737,) and data type uint64
+memory allocation of memory allocation of 1818775484491218187754844912 bytes failed
+Aborted (core dumped)
 ```
 
-and trying with `QAOA` backed with "qasm_simulator" produces:
+and trying with `QAOA` backed by the reference `StatevectorSampler` primitive
+produces:
 
 ```python
->>> from qiskit import BasicAer
->>> from qiskit.aqua import QuantumInstance
->>> from qiskit.aqua.algorithms import QAOA
-
->>> quantum_instance = QuantumInstance(BasicAer.get_backend('qasm_simulator'))
->>> qaoa_mes = QAOA(quantum_instance=quantum_instance, initial_point=[0., 0.])
->>> result = qaoa_mes.compute_minimum_eigenvalue(operator)
+>>> import numpy as np
+>>> from qiskit.primitives import StatevectorSampler
+>>> from qiskit_optimization.minimum_eigensolvers import QAOA
+>>> from qiskit_optimization.optimizers import COBYLA
+...
+>>> qaoa_mes = QAOA(sampler=StatevectorSampler(), optimizer=COBYLA(),
+...                 initial_point=np.array([0.0, 0.0]))
+>>> result = MinimumEigenOptimizer(qaoa_mes).solve(qp)
 # snipped for brevity
-BasicAerError: 'Number of qubits 36 is greater than maximum (24) for "qasm_simulator".'
+MemoryError: Unable to allocate 1.00 TiB for an array with shape (68719476736,) and data type complex128
 ```
 
 ## Installation
 
-Compatible with Python 3.6+, [Qiskit](https://github.com/Qiskit/qiskit) 0.23.0+,
-and [Ocean](https://github.com/dwavesystems/dwave-ocean-sdk) 3.1.0+.
+Compatible with Python 3.10+, [Qiskit](https://github.com/Qiskit/qiskit) 1.0+,
+[qiskit-optimization](https://github.com/qiskit-community/qiskit-optimization) 0.7+,
+and [Ocean](https://github.com/dwavesystems/dwave-ocean-sdk)'s dwave-system 1.20+.
 
 ```bash
 pip install dwave-qiskit-plugin
@@ -100,13 +94,12 @@ pip install dwave-qiskit-plugin
 
 To install from source:
 ```bash
-pip install -r requirements.txt
-python setup.py install
+pip install .
 ```
 
 Test requirements are in `tests/requirements.txt`.
 
-Note: [Configured access to D-Wave API](https://docs.ocean.dwavesys.com/en/latest/overview/sapi.html) is required.
+Note: [Configured access to D-Wave API](https://docs.dwavequantum.com/en/latest/ocean/sapi_access_basic.html) is required.
 
 
 ## License

--- a/dwave/plugins/qiskit/minimum_eigen_solvers/dwave_minimum_eigen_solver.py
+++ b/dwave/plugins/qiskit/minimum_eigen_solvers/dwave_minimum_eigen_solver.py
@@ -13,22 +13,23 @@
 # limitations under the License.
 
 import logging
-from typing import List, Optional, Union, Dict
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
-import numpy as np
 import dimod
 from dwave.system import DWaveSampler, AutoEmbeddingComposite
 
-from qiskit.aqua.operators import OperatorBase, LegacyBaseOperator, StateFn
-from qiskit.aqua.algorithms import MinimumEigensolver, MinimumEigensolverResult
-from qiskit.optimization.problems import QuadraticProgram
+from qiskit.quantum_info.operators.base_operator import BaseOperator
+from qiskit.result import QuasiDistribution
+from qiskit_optimization.problems import QuadraticProgram
+from qiskit_optimization.minimum_eigensolvers import (
+    SamplingMinimumEigensolver, SamplingMinimumEigensolverResult)
 
 __all__ = ['DWaveMinimumEigensolver']
 
 logger = logging.getLogger(__name__)
 
 
-class DWaveMinimumEigensolver(MinimumEigensolver):
+class DWaveMinimumEigensolver(SamplingMinimumEigensolver):
     """Obtain ground state(s) of an Ising Hamiltonian using D-Wave's QPU.
 
     Args:
@@ -62,9 +63,8 @@ class DWaveMinimumEigensolver(MinimumEigensolver):
     """
 
     def __init__(self,
-                 operator: Union[OperatorBase, LegacyBaseOperator] = None,
-                 aux_operators: Optional[List[Optional[Union[OperatorBase,
-                                                             LegacyBaseOperator]]]] = None,
+                 operator: Optional[BaseOperator] = None,
+                 aux_operators: Optional[List[Optional[BaseOperator]]] = None,
                  sampler: dimod.Sampler = None,
                  num_reads: int = 100,
                  ) -> None:
@@ -75,12 +75,14 @@ class DWaveMinimumEigensolver(MinimumEigensolver):
         self._sampler = sampler
         self._num_reads = num_reads
 
-    def supports_aux_operators(self) -> bool:
-        # NOTE: needed because of overly strict check on MinimumEigenOptimizer
-        # init (see: https://github.com/Qiskit/qiskit-aqua/issues/1306)
+    @classmethod
+    def supports_aux_operators(cls) -> bool:
+        # NOTE: MinimumEigenOptimizer refuses to work with solvers that do not
+        # claim aux operator support (it uses the flag as a proxy for "returns
+        # an eigenstate"), so this has to return True
         return True
 
-    def _operator_to_bqm(self, operator):
+    def _operator_to_bqm(self, operator: BaseOperator) -> dimod.BinaryQuadraticModel:
         """Convert an Ising Hamiltonian operator (with at most 2 Pauli Zs in
         any Pauli term) to a `~dimod.BinaryQuadraticModel` suitable for
         submission to a D-Wave sampler.
@@ -95,19 +97,19 @@ class DWaveMinimumEigensolver(MinimumEigensolver):
 
         # construct a BQM
         # (use to_array for linear coefficients to make sure implied, but not
-        # used, variables are included)
-        return dimod.AdjVectorBQM(qp.objective.linear.to_array(),
-                                  qp.objective.quadratic.to_dict(),
-                                  qp.objective.constant,
-                                  vartype=dimod.BINARY)
+        # used, variables are included; diagonal quadratic terms are folded
+        # into linear biases by dimod, as x**2 == x for binary variables)
+        return dimod.BinaryQuadraticModel(qp.objective.linear.to_array(),
+                                          qp.objective.quadratic.to_dict(),
+                                          qp.objective.constant,
+                                          vartype=dimod.BINARY)
 
     @property
-    def operator(self) -> Optional[OperatorBase]:
+    def operator(self) -> Optional[BaseOperator]:
         return self._operator
 
     @operator.setter
-    def operator(self,
-                 operator: Union[OperatorBase, LegacyBaseOperator]) -> None:
+    def operator(self, operator: Optional[BaseOperator]) -> None:
         """Convert an Ising Hamiltonian operator to a binary quadratic model
         suitable for submission to a D-Wave sampler.
 
@@ -130,22 +132,21 @@ class DWaveMinimumEigensolver(MinimumEigensolver):
             logger.debug('BQM set to %s', self._bqm)
 
     @property
-    def aux_operators(self) -> Optional[List[Optional[OperatorBase]]]:
+    def aux_operators(self) -> Optional[List[Optional[BaseOperator]]]:
         return self._aux_operators
 
     @aux_operators.setter
     def aux_operators(self,
                       aux_operators: Optional[
-                          Union[OperatorBase,
-                                LegacyBaseOperator,
-                                List[Optional[Union[OperatorBase,
-                                                    LegacyBaseOperator]]]]]) -> None:
+                          Union[BaseOperator,
+                                List[Optional[BaseOperator]]]]) -> None:
         if aux_operators is None:
             aux_operators = []
         if not isinstance(aux_operators, list):
             aux_operators = [aux_operators]
 
         self._aux_operators = aux_operators
+        self._aux_bqms = None
 
     @property
     def bqm(self) -> Optional[dimod.BinaryQuadraticModel]:
@@ -176,12 +177,13 @@ class DWaveMinimumEigensolver(MinimumEigensolver):
 
     def compute_minimum_eigenvalue(
             self,
-            operator: Optional[Union[OperatorBase, LegacyBaseOperator]] = None,
-            aux_operators: \
-                Optional[List[Optional[Union[OperatorBase,
-                                             LegacyBaseOperator]]]] = None
-    ) -> MinimumEigensolverResult:
-        super().compute_minimum_eigenvalue(operator, aux_operators)
+            operator: Optional[BaseOperator] = None,
+            aux_operators: Optional[List[Optional[BaseOperator]]] = None
+    ) -> SamplingMinimumEigensolverResult:
+        if operator is not None:
+            self.operator = operator
+        if aux_operators is not None:
+            self.aux_operators = aux_operators
         return self._run()
 
     def _sample(self) -> dimod.SampleSet:
@@ -191,25 +193,28 @@ class DWaveMinimumEigensolver(MinimumEigensolver):
         return self.sampler.sample(self.bqm, **params)
 
     @staticmethod
-    def _stringify(sample: np.ndarray) -> str:
-        """Convert numpy.ndarray vector of 0/1 int values to a bit string."""
-        return ''.join(map(str, sample))
+    def _stringify(sample: Dict, variables: Sequence) -> str:
+        """Convert a sample (mapping of variable to 0/1 value) to a bit string
+        in Qiskit's little-endian convention (variable/qubit 0 rightmost).
+        """
+        return ''.join(str(sample[v]) for v in reversed(variables))
 
-    def _eval_aux_operators(self, state) -> np.ndarray:
-        """Evaluate all aux_operators on the input state."""
-        # NOTE: for lack of better specs, we follow the NumPyEigensolver format
-        values = [(StateFn(operator, is_measurement=True).eval(state).real, 0)
-                  for operator in self._aux_operators]
-        return np.array(values, dtype=object)
+    def _eval_aux_operators(
+            self, samples: List[Tuple[Dict, float]]) -> List[Tuple[float, dict]]:
+        """Evaluate all aux_operators as expectation values over the
+        probability-weighted (ground state) samples.
+        """
+        return [(sum(p * bqm.energy(sample) for sample, p in samples), {})
+                for bqm in self.aux_bqms]
 
-    def _run(self) -> MinimumEigensolverResult:
+    def _run(self) -> SamplingMinimumEigensolverResult:
         """Sample the Ising Hamiltonian provided on a D-Wave QPU to obtain the
         ground state(s).
 
         Returns:
-            MinimumEigensolverResult:
-                Dictionary of results, namely samples in `eigenstate` and
-                energies in `eigenvalue`.
+            SamplingMinimumEigensolverResult:
+                Results, namely a quasi-distribution over ground state samples
+                in `eigenstate` and the lowest energy in `eigenvalue`.
 
         Raises:
             ValueError:
@@ -228,34 +233,44 @@ class DWaveMinimumEigensolver(MinimumEigensolver):
         ground = sampleset.lowest(rtol=0)
         logger.debug('ground states (%d): %r', len(ground), ground)
 
-        result = MinimumEigensolverResult()
+        variables = sorted(ground.variables)
+        total = int(ground.record.num_occurrences.sum())
+
+        # probability-weighted ground state samples
+        samples = [(datum.sample, datum.num_occurrences / total)
+                   for datum in ground.data(fields=['sample', 'num_occurrences'])]
+
+        result = SamplingMinimumEigensolverResult()
         result.eigenvalue = ground.first.energy
 
-        # NOTE: due to inconsistencies in how DictStateFn values are handled in
-        # `MinimumEigenOptimizer` and `DictStateFn` itself (probs vs amplitudes),
-        # the safest (for now) is to follow QAOA's approach and return
-        # counts/reads per eigenstate (when in superposition).
-        result.eigenstate = {self._stringify(rec.sample): rec.num_occurrences
-                             for rec in ground.record}
+        # NOTE: `MinimumEigenOptimizer` interprets eigenstate bitstrings in
+        # Qiskit's little-endian convention, i.e. variable/qubit 0 rightmost
+        result.eigenstate = QuasiDistribution(
+            {self._stringify(sample, variables): p for sample, p in samples})
+
+        best = self._stringify(ground.first.sample, variables)
+        result.best_measurement = {
+            'state': int(best, 2),
+            'bitstring': best,
+            'value': ground.first.energy,
+            'probability': ground.first.num_occurrences / total,
+        }
 
         # optionally, evaluate aux_operators
         if self._aux_operators:
-            result.aux_operator_eigenvalues = [self._eval_aux_operators(bitstr)
-                                               for bitstr in result.eigenstate]
+            result.aux_operators_evaluated = self._eval_aux_operators(samples)
 
         # include all samples for inspection
         result.sampleset = sampleset
 
-        logger.debug('run result: %r', result.data)
+        logger.debug('run result: %r', result)
 
         return result
 
     def run(self,
-            operator: Optional[Union[OperatorBase, LegacyBaseOperator]] = None,
-            aux_operators: \
-                Optional[List[Optional[Union[OperatorBase,
-                                             LegacyBaseOperator]]]] = None
-    ) -> MinimumEigensolverResult:
+            operator: Optional[BaseOperator] = None,
+            aux_operators: Optional[List[Optional[BaseOperator]]] = None
+    ) -> SamplingMinimumEigensolverResult:
         """Obtain ground state(s) of an Ising Hamiltonian using D-Wave's QPU.
         """
         return self.compute_minimum_eigenvalue(operator, aux_operators)

--- a/dwave/plugins/qiskit/minimum_eigen_solvers/dwave_minimum_eigen_solver.py
+++ b/dwave/plugins/qiskit/minimum_eigen_solvers/dwave_minimum_eigen_solver.py
@@ -94,7 +94,9 @@ class DWaveMinimumEigensolver(SamplingMinimumEigensolver):
         qp.from_ising(operator)
 
         # sanity check
-        assert qp.objective.sense is qp.objective.Sense.MINIMIZE
+        if qp.objective.sense is not qp.objective.Sense.MINIMIZE:
+            raise RuntimeError(f"Unexpected objective sense {qp.objective.sense} "
+                               "for the quadratic program generated from an Ising Hamiltonian")
 
         # construct a BQM
         # (use to_array for linear coefficients to make sure implied, but not

--- a/dwave/plugins/qiskit/minimum_eigen_solvers/dwave_minimum_eigen_solver.py
+++ b/dwave/plugins/qiskit/minimum_eigen_solvers/dwave_minimum_eigen_solver.py
@@ -21,6 +21,7 @@ from dwave.system import DWaveSampler, AutoEmbeddingComposite
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.result import QuasiDistribution
 from qiskit_optimization.problems import QuadraticProgram
+from qiskit_optimization.minimum_eigensolvers.list_or_dict import ListOrDict
 from qiskit_optimization.minimum_eigensolvers import (
     SamplingMinimumEigensolver, SamplingMinimumEigensolverResult)
 
@@ -65,8 +66,8 @@ class DWaveMinimumEigensolver(SamplingMinimumEigensolver):
 
     def __init__(self,
                  operator: Optional[BaseOperator] = None,
-                 aux_operators: Optional[List[Optional[BaseOperator]]] = None,
-                 sampler: dimod.Sampler = None,
+                 aux_operators: Optional[ListOrDict[BaseOperator]] = None,
+                 sampler: Optional[dimod.Sampler] = None,
                  num_reads: int = 100,
                  ) -> None:
         super().__init__()
@@ -139,14 +140,9 @@ class DWaveMinimumEigensolver(SamplingMinimumEigensolver):
         return self._aux_operators
 
     @aux_operators.setter
-    def aux_operators(self,
-                      aux_operators: Optional[
-                          Union[BaseOperator,
-                                List[Optional[BaseOperator]]]]) -> None:
+    def aux_operators(self, aux_operators: Optional[ListOrDict[BaseOperator]] = None) -> None:
         if aux_operators is None:
             aux_operators = []
-        if not isinstance(aux_operators, list):
-            aux_operators = [aux_operators]
 
         self._aux_operators = aux_operators
         self._aux_bqms = None
@@ -161,13 +157,25 @@ class DWaveMinimumEigensolver(SamplingMinimumEigensolver):
         return bqm
 
     @property
-    def aux_bqms(self) -> List[dimod.BinaryQuadraticModel]:
+    def aux_bqms(self) -> ListOrDict[dimod.BinaryQuadraticModel]:
         """Binary quadratic model representations of auxiliary Ising Hamiltonian
         operators.
         """
         bqms = getattr(self, '_aux_bqms', None)
+
         if bqms is None:
-            bqms = self._aux_bqms = [self._operator_to_bqm(aux_op) for aux_op in self.aux_operators]
+            if isinstance(self.aux_operators, list):
+                bqms = [None] * len(self.aux_operators)
+                key_op_iterator = enumerate(self.aux_operators)
+            else:
+                bqms = {}
+                key_op_iterator = self.aux_operators.items()
+
+            for key, operator in key_op_iterator:
+                bqms[key] = self._operator_to_bqm(operator)
+
+            self._aux_bqms = bqms
+
         return bqms
 
     @property
@@ -201,12 +209,21 @@ class DWaveMinimumEigensolver(SamplingMinimumEigensolver):
         return ''.join(str(sample[v]) for v in reversed(variables))
 
     def _eval_aux_operators(
-            self, samples: List[Tuple[Dict, float]]) -> List[Tuple[float, dict]]:
+            self, samples: List[Tuple[Dict, float]]) -> ListOrDict[Tuple[float, Dict[str, float]]]:
         """Evaluate all aux_operators as expectation values over the
         probability-weighted (ground state) samples.
         """
-        return [(sum(p * bqm.energy(sample) for sample, p in samples), {})
-                for bqm in self.aux_bqms]
+        if isinstance(self.aux_bqms, list):
+            values = [None] * len(self.aux_bqms)
+            key_bqm_iterator = enumerate(self.aux_bqms)
+        else:
+            values = {}
+            key_bqm_iterator = self.aux_bqms.items()
+
+        for key, bqm in key_bqm_iterator:
+            values[key] = (sum(p * bqm.energy(sample) for sample, p in samples), {})
+
+        return values
 
     def _run(self) -> SamplingMinimumEigensolverResult:
         """Sample the Ising Hamiltonian provided on a D-Wave QPU to obtain the

--- a/dwave/plugins/qiskit/minimum_eigen_solvers/dwave_minimum_eigen_solver.py
+++ b/dwave/plugins/qiskit/minimum_eigen_solvers/dwave_minimum_eigen_solver.py
@@ -41,7 +41,8 @@ class DWaveMinimumEigensolver(SamplingMinimumEigensolver):
         sampler:
             Instantiated D-Wave sampler. Defaults to
             ~dwave.system.AutoEmbeddingComposite`-wrapped
-            `~dwave.system.DWaveSampler` over a QPU solver.
+           :class:`~dwave.system.AutoEmbeddingComposite`-wrapped
+           :class:`~dwave.system.DWaveSampler` over a QPU solver.
         num_reads:
             Number of QPU reads.
 
@@ -149,7 +150,7 @@ class DWaveMinimumEigensolver(SamplingMinimumEigensolver):
         self._aux_bqms = None
 
     @property
-    def bqm(self) -> Optional[dimod.BinaryQuadraticModel]:
+    def bqm(self) -> dimod.BinaryQuadraticModel:
         """Binary quadratic model representation of Ising Hamiltonian operator.
         """
         bqm = getattr(self, '_bqm', None)
@@ -158,7 +159,7 @@ class DWaveMinimumEigensolver(SamplingMinimumEigensolver):
         return bqm
 
     @property
-    def aux_bqms(self) -> Optional[List[dimod.BinaryQuadraticModel]]:
+    def aux_bqms(self) -> List[dimod.BinaryQuadraticModel]:
         """Binary quadratic model representations of auxiliary Ising Hamiltonian
         operators.
         """

--- a/dwave/plugins/qiskit/minimum_eigen_solvers/dwave_minimum_eigen_solver.py
+++ b/dwave/plugins/qiskit/minimum_eigen_solvers/dwave_minimum_eigen_solver.py
@@ -183,10 +183,8 @@ class DWaveMinimumEigensolver(SamplingMinimumEigensolver):
             operator: Optional[BaseOperator] = None,
             aux_operators: Optional[List[Optional[BaseOperator]]] = None
     ) -> SamplingMinimumEigensolverResult:
-        if operator is not None:
-            self.operator = operator
-        if aux_operators is not None:
-            self.aux_operators = aux_operators
+        self.operator = operator
+        self.aux_operators = aux_operators
         return self._run()
 
     def _sample(self) -> dimod.SampleSet:

--- a/releasenotes/notes/migrate-to-modern-qiskit-608c9f29a02ada60.yaml
+++ b/releasenotes/notes/migrate-to-modern-qiskit-608c9f29a02ada60.yaml
@@ -1,0 +1,45 @@
+---
+prelude: >
+    ``DWaveMinimumEigensolver`` is ported from the retired qiskit-aqua stack
+    to modern Qiskit. It now implements qiskit-optimization's
+    ``SamplingMinimumEigensolver`` interface and works with ``qiskit>=1.0``
+    (tested with 2.x) and ``qiskit-optimization>=0.7``.
+upgrade:
+  - |
+    Python 3.10 or newer is now required. Support for Python 3.6-3.9 is
+    dropped.
+  - |
+    Dependencies changed from ``qiskit-aqua>=0.8.0`` to ``qiskit>=1.0`` and
+    ``qiskit-optimization>=0.7``, and ``dwave-system`` is raised to
+    ``>=1.20``. The package intentionally does not depend on
+    ``qiskit-algorithms`` (in maintenance mode); the solver subclasses
+    ``qiskit_optimization.minimum_eigensolvers.SamplingMinimumEigensolver``
+    vendored by qiskit-optimization.
+  - |
+    ``DWaveMinimumEigensolver.compute_minimum_eigenvalue()`` now returns a
+    ``SamplingMinimumEigensolverResult``. The ``eigenstate`` attribute is a
+    ``qiskit.result.QuasiDistribution`` of probabilities over ground-state
+    bitstrings, replacing the previous dict of per-state read counts; use
+    ``result.eigenstate.binary_probabilities()`` to get bitstring keys. A
+    QAOA-style ``best_measurement`` mapping is also populated, and the raw
+    ``dimod.SampleSet`` remains attached as ``result.sampleset``.
+  - |
+    Eigenstate bitstrings now follow Qiskit's little-endian convention:
+    variable/qubit 0 is the rightmost character. Previously variable 0 was
+    the leftmost character. This matches how
+    ``MinimumEigenOptimizer._eigenvector_to_solutions()`` maps bitstrings
+    back to problem variables in modern qiskit-optimization; without this
+    change, solutions of asymmetric problems would be silently corrupted.
+  - |
+    Operators are accepted as ``qiskit.quantum_info.SparsePauliOp`` (or any
+    ``BaseOperator`` convertible by qiskit-optimization's ``from_ising``
+    translator). Legacy opflow operator types (``OperatorBase``,
+    ``LegacyBaseOperator``, ``StateFn``, ``SummedOp``, ``MatrixOp``) are no
+    longer supported, as they were removed from Qiskit.
+  - |
+    Auxiliary operator results moved from ``result.aux_operator_eigenvalues``
+    to ``result.aux_operators_evaluated``, formatted as ``(value, metadata)``
+    tuples. Values are now expectation values over the returned ground-state
+    distribution, computed classically from the operators' binary quadratic
+    model form, instead of per-ground-state evaluations via opflow
+    ``StateFn``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 qiskit==2.5.1
 qiskit-optimization==0.7.0
 dwave-system==1.35.0
+
+# dev requirements
+reno~=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-qiskit-aqua==0.8.1
-dwave-system==1.2.1
+qiskit==2.5.1
+qiskit-optimization==0.7.0
+dwave-system==1.35.0

--- a/setup.py
+++ b/setup.py
@@ -24,17 +24,18 @@ with open(package_info_path, encoding='utf-8') as f:
     exec(f.read(), package_info)
 
 
-install_requires = ['qiskit-aqua>=0.8.0', 'dwave-system>=1.2.0']
+install_requires = ['qiskit>=1.0', 'qiskit-optimization>=0.7', 'dwave-system>=1.20']
 
-python_requires = ">=3.6"
+python_requires = ">=3.10"
 
 classifiers = [
     'License :: OSI Approved :: Apache Software License',
     'Operating System :: OS Independent',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
 
 packages = [pkg for pkg in find_packages() if pkg.startswith('dwave.plugins.qiskit')]

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
 ]
 
 packages = [pkg for pkg in find_packages() if pkg.startswith('dwave.plugins.qiskit')]

--- a/tests/test_dwave_minimum_eigen_solver.py
+++ b/tests/test_dwave_minimum_eigen_solver.py
@@ -95,8 +95,8 @@ class TestMinimumEigensolver(unittest.TestCase):
             dwave_mes.compute_minimum_eigenvalue()
 
         # manually set operator
-        dwave_mes.operator = operator
-        result = dwave_mes.compute_minimum_eigenvalue()
+        result = dwave_mes.compute_minimum_eigenvalue(operator=operator)
+        self.assertEqual(dwave_mes.operator, operator)
         self.assertEqual(result.eigenvalue, -0.5)
         self.assertIsInstance(result.eigenstate, QuasiDistribution)
         self.assertDictEqual(result.eigenstate.binary_probabilities(), {'1': 1.0})
@@ -104,13 +104,9 @@ class TestMinimumEigensolver(unittest.TestCase):
         self.assertEqual(result.best_measurement['value'], -0.5)
 
         # test aux operator
-        dwave_mes.aux_operators = [operator]
-        result = dwave_mes.compute_minimum_eigenvalue()
-        self.assertEqual(len(result.aux_operators_evaluated), 1)
-
-        # test getters
-        self.assertEqual(dwave_mes.operator, operator)
+        result = dwave_mes.compute_minimum_eigenvalue(aux_operators=[operator])
         self.assertEqual(dwave_mes.aux_operators, [operator])
+        self.assertEqual(len(result.aux_operators_evaluated), 1)
 
         # test .run
         result = dwave_mes.run()

--- a/tests/test_dwave_minimum_eigen_solver.py
+++ b/tests/test_dwave_minimum_eigen_solver.py
@@ -138,7 +138,7 @@ class TestMinimumEigensolver(unittest.TestCase):
         self.assertEqual(set(eigenstate), set(ground_states))
         self.assertAlmostEqual(sum(eigenstate.values()), 1)
 
-    def test_aux_operators(self):
+    def test_aux_operators_as_list(self):
         # two ground states: '01', '10'
         operator = SparsePauliOp('ZZ')
         bqm = dimod.BQM.from_ising({}, {(0, 1): 1}).binary
@@ -153,12 +153,34 @@ class TestMinimumEigensolver(unittest.TestCase):
 
         # verify conversion to bqm
         self.assertEqual(dwave_mes.bqm, bqm)
-        self.assertListEqual(dwave_mes.aux_bqms, aux_bqms)
+        self.assertEqual(dwave_mes.aux_bqms, aux_bqms)
 
         # verify aux_operator expectations over the two degenerate ground
         # states average out to zero: (-1 + 1)/2 and (+1 - 1)/2
         self.assertEqual(result.aux_operators_evaluated[0][0], 0)
         self.assertEqual(result.aux_operators_evaluated[1][0], 0)
+
+    def test_aux_operators_as_dict(self):
+        # two ground states: '01', '10'
+        operator = SparsePauliOp('ZZ')
+        bqm = dimod.BQM.from_ising({}, {(0, 1): 1}).binary
+
+        aux_operators = {'01': SparsePauliOp('IZ'), '10': SparsePauliOp('ZI')}
+        aux_bqms = {'01': dimod.BQM.from_ising({0: -1, 1: 0}, {}).binary,
+                    '10': dimod.BQM.from_ising({0: 0, 1: -1}, {}).binary}
+
+        # use exact solver as sampler
+        dwave_mes = DWaveMinimumEigensolver(sampler=dimod.ExactSolver())
+        result = dwave_mes.compute_minimum_eigenvalue(operator, aux_operators)
+
+        # verify conversion to bqm
+        self.assertEqual(dwave_mes.bqm, bqm)
+        self.assertEqual(dwave_mes.aux_bqms, aux_bqms)
+
+        # verify aux_operator expectations over the two degenerate ground
+        # states average out to zero: (-1 + 1)/2 and (+1 - 1)/2
+        self.assertEqual(result.aux_operators_evaluated['01'][0], 0)
+        self.assertEqual(result.aux_operators_evaluated['10'][0], 0)
 
 
 class TestMinimumEigenOptimizerFlow(unittest.TestCase):

--- a/tests/test_dwave_minimum_eigen_solver.py
+++ b/tests/test_dwave_minimum_eigen_solver.py
@@ -23,7 +23,6 @@ from qiskit.result import QuasiDistribution
 from qiskit_optimization import QuadraticProgram, QiskitOptimizationError
 from qiskit_optimization.algorithms import (
     MinimumEigenOptimizer, OptimizationResultStatus)
-from qiskit_optimization.converters import QuadraticProgramToQubo
 from qiskit_optimization.minimum_eigensolvers import NumPyMinimumEigensolver
 from qiskit_optimization.translators import to_ising
 
@@ -318,7 +317,6 @@ class TestMinimumEigenOptimizerOnDWave(unittest.TestCase):
 
         # NOTE: auto penalty in LinearEqualityToPenalty is >100, resulting with
         # big dynamic range of QUBO coefficients. Try with penalty=1
-        #qubo = QuadraticProgramToQubo(penalty=1).convert(qp)
 
         # solve with Numpy MES
         numpy_mes = NumPyMinimumEigensolver()

--- a/tests/test_dwave_minimum_eigen_solver.py
+++ b/tests/test_dwave_minimum_eigen_solver.py
@@ -16,15 +16,16 @@ import random
 import unittest
 import itertools
 
-from parameterized import parameterized, param
+from parameterized import parameterized
 
-from qiskit.aqua.operators import X, Y, Z, I, MatrixOp, SummedOp, StateFn
-from qiskit.aqua.algorithms import NumPyMinimumEigensolver
-from qiskit.optimization import QuadraticProgram, QiskitOptimizationError
-from qiskit.optimization.algorithms import MinimumEigenOptimizer
-from qiskit.optimization.converters import QuadraticProgramToQubo
-from qiskit.optimization.applications.ising.common import sample_most_likely
-from qiskit.optimization.algorithms.optimization_algorithm import OptimizationResultStatus
+from qiskit.quantum_info import SparsePauliOp, Operator
+from qiskit.result import QuasiDistribution
+from qiskit_optimization import QuadraticProgram, QiskitOptimizationError
+from qiskit_optimization.algorithms import (
+    MinimumEigenOptimizer, OptimizationResultStatus)
+from qiskit_optimization.converters import QuadraticProgramToQubo
+from qiskit_optimization.minimum_eigensolvers import NumPyMinimumEigensolver
+from qiskit_optimization.translators import to_ising
 
 import dimod
 from dwave.system import DWaveSampler, EmbeddingComposite, DWaveCliqueSampler
@@ -51,12 +52,14 @@ def create_random_qubo_qp(size=3, min_bias=-1, max_bias=1, seed=None):
 class TestMinimumEigensolver(unittest.TestCase):
 
     @parameterized.expand([
-        ("Z", Z, ({0: -1}, {})),
-        ("IZ", I^Z, ({0: -1, 1: 0}, {})),
-        ("ZZ", Z^Z, ({}, {(0, 1): 1})),
-        ("IZZI", I^Z^Z^I, ({0: 0, 1: 0, 2: 0, 3: 0}, {(1, 2): 1})),
-        ("IZZ+ZIZ", SummedOp([I^Z^Z, 2 * Z^I^Z]), ({}, {(0, 1): 1, (0, 2): 2})),
-        ("Z_matrix", MatrixOp([[1, 0], [0, -1]]), ({0: -1}, {})),
+        ("Z", SparsePauliOp('Z'), ({0: -1}, {})),
+        ("IZ", SparsePauliOp('IZ'), ({0: -1, 1: 0}, {})),
+        ("ZZ", SparsePauliOp('ZZ'), ({}, {(0, 1): 1})),
+        ("IZZI", SparsePauliOp('IZZI'), ({0: 0, 1: 0, 2: 0, 3: 0}, {(1, 2): 1})),
+        ("IZZ+ZIZ", SparsePauliOp(['IZZ', 'ZIZ'], coeffs=[1, 2]),
+         ({}, {(0, 1): 1, (0, 2): 2})),
+        ("Z_matrix", SparsePauliOp.from_operator(Operator([[1, 0], [0, -1]])),
+         ({0: -1}, {})),
     ])
     def test_operator_conversion(self, name, operator, ising):
         mes = DWaveMinimumEigensolver(operator)
@@ -65,8 +68,8 @@ class TestMinimumEigensolver(unittest.TestCase):
         self.assertEqual(mes.bqm.spin, bqm)
 
     @parameterized.expand([
-        ("ZZZ", Z^Z^Z),
-        ("X", X),
+        ("ZZZ", SparsePauliOp('ZZZ')),
+        ("X", SparsePauliOp('X')),
     ])
     def test_non_ising_operator(self, name, operator):
         with self.assertRaises(QiskitOptimizationError):
@@ -79,7 +82,7 @@ class TestMinimumEigensolver(unittest.TestCase):
         qp = QuadraticProgram()
         qp.binary_var('x')
         qp.minimize(linear=[-1])
-        operator, offset = qp.to_ising()
+        operator, offset = to_ising(qp)
 
         # use exact solver as sampler
         sampler = dimod.ExactSolver()
@@ -96,13 +99,15 @@ class TestMinimumEigensolver(unittest.TestCase):
         dwave_mes.operator = operator
         result = dwave_mes.compute_minimum_eigenvalue()
         self.assertEqual(result.eigenvalue, -0.5)
-        self.assertIsInstance(result.eigenstate, dict)
-        self.assertDictEqual(result.eigenstate, {'1': 1})
+        self.assertIsInstance(result.eigenstate, QuasiDistribution)
+        self.assertDictEqual(result.eigenstate.binary_probabilities(), {'1': 1.0})
+        self.assertEqual(result.best_measurement['bitstring'], '1')
+        self.assertEqual(result.best_measurement['value'], -0.5)
 
         # test aux operator
         dwave_mes.aux_operators = [operator]
         result = dwave_mes.compute_minimum_eigenvalue()
-        self.assertEqual(len(result.aux_operator_eigenvalues), 1)
+        self.assertEqual(len(result.aux_operators_evaluated), 1)
 
         # test getters
         self.assertEqual(dwave_mes.operator, operator)
@@ -114,33 +119,36 @@ class TestMinimumEigensolver(unittest.TestCase):
 
     def test_degenerate_ground_states(self):
         # ground states: '0', '1'
-        operator = 0 * Z
+        operator = SparsePauliOp('Z', coeffs=[0])
 
         # use exact solver as sampler
         dwave_mes = DWaveMinimumEigensolver(sampler=dimod.ExactSolver())
 
         result = dwave_mes.compute_minimum_eigenvalue(operator)
         self.assertEqual(result.eigenvalue, 0)
-        self.assertDictEqual(result.eigenstate, {'0': 1, '1': 1})
+        self.assertDictEqual(result.eigenstate.binary_probabilities(),
+                             {'0': 0.5, '1': 0.5})
 
     def test_ground_states_returned_only(self):
         # two ground states, six excited states
-        operator = SummedOp([I^Z^Z, 2 * Z^I^Z])
-        ground_states = ['100', '011']
+        operator = SparsePauliOp(['IZZ', 'ZIZ'], coeffs=[1, 2])
+        # in Qiskit's little-endian convention (variable/qubit 0 rightmost)
+        ground_states = ['001', '110']
 
         # use exact solver as sampler
         dwave_mes = DWaveMinimumEigensolver(sampler=dimod.ExactSolver())
 
         result = dwave_mes.compute_minimum_eigenvalue(operator)
-        self.assertEqual(set(result.eigenstate), set(ground_states))
-        self.assertEqual(sum(result.eigenstate.values()), 2)
+        eigenstate = result.eigenstate.binary_probabilities()
+        self.assertEqual(set(eigenstate), set(ground_states))
+        self.assertAlmostEqual(sum(eigenstate.values()), 1)
 
     def test_aux_operators(self):
         # two ground states: '01', '10'
-        operator = Z^Z
+        operator = SparsePauliOp('ZZ')
         bqm = dimod.BQM.from_ising({}, {(0, 1): 1}).binary
 
-        aux_operators = [I^Z, Z^I]
+        aux_operators = [SparsePauliOp('IZ'), SparsePauliOp('ZI')]
         aux_bqms = [dimod.BQM.from_ising({0: -1, 1: 0}, {}).binary,
                     dimod.BQM.from_ising({0: 0, 1: -1}, {}).binary]
 
@@ -152,9 +160,10 @@ class TestMinimumEigensolver(unittest.TestCase):
         self.assertEqual(dwave_mes.bqm, bqm)
         self.assertListEqual(dwave_mes.aux_bqms, aux_bqms)
 
-        # verify aux_operator eigenvalues (-1, +1) and (+1, -1)
-        self.assertEqual(sum(result.aux_operator_eigenvalues[0][:,0]), 0)
-        self.assertEqual(sum(result.aux_operator_eigenvalues[1][:,0]), 0)
+        # verify aux_operator expectations over the two degenerate ground
+        # states average out to zero: (-1 + 1)/2 and (+1 - 1)/2
+        self.assertEqual(result.aux_operators_evaluated[0][0], 0)
+        self.assertEqual(result.aux_operators_evaluated[1][0], 0)
 
 
 class TestMinimumEigenOptimizerFlow(unittest.TestCase):
@@ -193,10 +202,26 @@ class TestMinimumEigenOptimizerFlow(unittest.TestCase):
         # verify all ground states are present
         self.assertEqual(len(result.x), qp.get_num_vars())
         self.assertEqual(len(result.samples), len(ground_states))
-        self.assertSetEqual(set(sample for sample, _, _ in result.samples), ground_states)
+        self.assertSetEqual(
+            set(''.join(str(int(v)) for v in sample.x) for sample in result.samples),
+            ground_states)
 
         # verify raw sampleset is accessible
         self.assertEqual(len(result.min_eigen_solver_result.sampleset), 2 ** qp.get_num_vars())
+
+    def test_asymmetric_solution(self):
+        # regression check for bit ordering: unique ground state [0, 1]
+        qp = QuadraticProgram()
+        qp.binary_var('x')
+        qp.binary_var('y')
+        qp.minimize(linear=[1, -2], quadratic={'xy': 1})
+
+        dwave_mes = DWaveMinimumEigensolver(sampler=dimod.ExactSolver())
+        optimizer = MinimumEigenOptimizer(dwave_mes)
+        result = optimizer.solve(qp)
+
+        self.assertEqual(list(result.x), [0.0, 1.0])
+        self.assertEqual(result.fval, -2.0)
 
 
 class TestMinimumEigenOptimizerOnDWave(unittest.TestCase):
@@ -228,11 +253,11 @@ class TestMinimumEigenOptimizerOnDWave(unittest.TestCase):
         self.assertEqual(result.status, OptimizationResultStatus.SUCCESS)
 
     def test_solver_selection(self):
-        """QP is solved on a QPU with Chimera topology and embedded with a clique embedder."""
+        """QP is solved on a QPU with Zephyr topology and embedded with a clique embedder."""
 
         qp = create_random_qubo_qp(size=3, seed=123)
 
-        sampler = DWaveCliqueSampler(solver=dict(topology__type='chimera'))
+        sampler = DWaveCliqueSampler(solver=dict(topology__type='zephyr'))
         mes = DWaveMinimumEigensolver(sampler=sampler)
         result = MinimumEigenOptimizer(mes).solve(qp)
 


### PR DESCRIPTION
Port DWaveMinimumEigensolver from the removed qiskit-aqua/opflow APIs to qiskit>=1.0 and qiskit-optimization>=0.7, subclassing the vendored SamplingMinimumEigensolver (no qiskit-algorithms dependency).

- Return SamplingMinimumEigensolverResult with a QuasiDistribution eigenstate and best_measurement; keep raw sampleset attached
- Emit eigenstate bitstrings in Qiskit's little-endian convention, as MinimumEigenOptimizer reverses them when mapping back to variables; add an asymmetric-problem regression test for the ordering
- Replace removed dimod.AdjVectorBQM with dimod.BinaryQuadraticModel; diagonal quadratic terms from modern from_ising fold into linear
- Evaluate aux operators as BQM-energy expectations over the ground-state distribution, replacing opflow StateFn
- Rebuild test operators as SparsePauliOp; assert eigenstates via binary_probabilities()
- Require Python 3.10+; update CI matrices to 3.10-3.13 on cimg/python images (3.14 blocked on qiskit wheels)
- Update README examples to the modern API, and add CLAUDE.md

#### AI Generation Disclosure

Most code changes generated by Claude. I reviewed and tested all changes.