### PR TITLE
Add D-Wave/QCDL provider

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,44 @@ Translate a Bell state Qiskit circuit into a QCDL program:
        measure([q1], q1, log=True, tag="1")
     end quantum
 
+DWaveProvider
+=============
+
+``DWaveProvider`` exposes D-Wave's Leap QCDL simulator solvers
+through the standard Qiskit provider/backend interface: circuits passed to
+``QCDLSimulatorBackend.run()`` are translated to QCDL, submitted to a Leap solver,
+and the answers are returned as a ``qiskit.result.Result``. Leap credentials are
+picked up from the standard `dwave-cloud-client configuration
+<https://docs.dwavequantum.com/en/latest/ocean/api_ref_cloud/config.html>`_
+(configuration file or environment variables), or can be passed to the
+provider directly.
+
+Examples
+--------
+
+Run a Bell state circuit on a Leap QCDL solver:
+
+.. code-block:: python
+
+    >>> from qiskit import QuantumCircuit
+    >>> from dwave.plugins.qiskit import DWaveProvider
+    ...
+    >>> qc = QuantumCircuit(2, 2, name="bell")
+    >>> qc.h(0)
+    >>> qc.cx(0, 1)
+    >>> qc.measure([0, 1], [0, 1])
+    ...
+    >>> with DWaveProvider() as provider:
+    ...     backend = provider.get_backend()
+    ...     job = backend.run(qc, shots=1000)
+    ...     counts = job.result().get_counts()
+    >>> counts                                      # doctest: +SKIP
+    {'00': 512, '11': 488}
+
+``run()`` also accepts a list of circuits; by default they are packed into as
+few QCDL programs as estimated to fit (disable with ``qcdl_pack_target=False``
+to submit one QCDL program per circuit).
+
 Installation
 ============
 

--- a/README.rst
+++ b/README.rst
@@ -129,8 +129,8 @@ DWaveProvider
 ``DWaveProvider`` exposes D-Wave's Leap QCDL simulator solvers
 through the standard Qiskit provider/backend interface: circuits passed to
 ``QCDLSimulatorBackend.run()`` are translated to QCDL, submitted to a Leap solver,
-and the answers are returned as a ``qiskit.result.Result``. Leap credentials are
-picked up from the standard `dwave-cloud-client configuration
+and the answers are returned in ``QCDLResult``, a ``qiskit.result.Result`` subclass.
+Leap credentials are picked up from the standard `dwave-cloud-client configuration
 <https://docs.dwavequantum.com/en/latest/ocean/api_ref_cloud/config.html>`_
 (configuration file or environment variables), or can be passed to the
 provider directly.
@@ -158,13 +158,13 @@ Run a Bell state circuit on a Leap QCDL solver:
     {'00': 512, '11': 488}
 
 ``run()`` also accepts a list of circuits; by default they are packed into as
-few QCDL programs as estimated to fit (disable with ``qcdl_pack_target=False``
+few QCDL programs as estimated to fit (disable with ``pack_qcdls=False``
 to submit one QCDL program per circuit).
 
 Installation
 ============
 
-Compatible with Python 3.11+, `Qiskit <https://github.com/Qiskit/qiskit>`_ 1.0+,
+Compatible with Python 3.11+, `Qiskit <https://github.com/Qiskit/qiskit>`_ 2.0+,
 `qiskit-optimization <https://github.com/qiskit-community/qiskit-optimization>`_ 0.7+,
 and `Ocean <https://github.com/dwavesystems/dwave-ocean-sdk>`_'s dwave-system 1.20+.
 

--- a/dwave/plugins/qiskit/leap/__init__.py
+++ b/dwave/plugins/qiskit/leap/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 D-Wave Systems Inc.
+# Copyright 2026 D-Wave
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .leap import DWaveProvider
-from .minimum_eigen_solvers import DWaveMinimumEigensolver
+from dwave.plugins.qiskit.leap.backend import QCDLBackend
+from dwave.plugins.qiskit.leap.job import QCDLJob
+from dwave.plugins.qiskit.leap.provider import DWaveProvider
 
-__all__ = [
-    'DWaveMinimumEigensolver',
-    'DWaveProvider',
-]
-
-__version__ = '0.1.0'
+__all__ = ["DWaveProvider", "QCDLBackend", "QCDLJob"]

--- a/dwave/plugins/qiskit/leap/__init__.py
+++ b/dwave/plugins/qiskit/leap/__init__.py
@@ -15,5 +15,6 @@
 from dwave.plugins.qiskit.leap.backend import QCDLSimulatorBackend
 from dwave.plugins.qiskit.leap.job import QCDLJob
 from dwave.plugins.qiskit.leap.provider import DWaveProvider
+from dwave.plugins.qiskit.leap.result import QCDLResult
 
-__all__ = ["DWaveProvider", "QCDLJob", "QCDLSimulatorBackend"]
+__all__ = ["DWaveProvider", "QCDLJob", "QCDLResult", "QCDLSimulatorBackend"]

--- a/dwave/plugins/qiskit/leap/__init__.py
+++ b/dwave/plugins/qiskit/leap/__init__.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dwave.plugins.qiskit.leap.backend import QCDLBackend
+from dwave.plugins.qiskit.leap.backend import QCDLSimulatorBackend
 from dwave.plugins.qiskit.leap.job import QCDLJob
 from dwave.plugins.qiskit.leap.provider import DWaveProvider
 
-__all__ = ["DWaveProvider", "QCDLBackend", "QCDLJob"]
+__all__ = ["DWaveProvider", "QCDLJob", "QCDLSimulatorBackend"]

--- a/dwave/plugins/qiskit/leap/backend.py
+++ b/dwave/plugins/qiskit/leap/backend.py
@@ -21,6 +21,8 @@ import uuid
 from functools import cached_property
 from typing import Any, TYPE_CHECKING
 
+from dwave.gate.results import YieldHandling
+
 from qiskit import QuantumCircuit
 from qiskit.circuit import Measure
 from qiskit.circuit.library.standard_gates import get_standard_gate_name_mapping
@@ -83,6 +85,9 @@ class QCDLSimulatorBackend(BackendV2):
         self.options.set_validator("repeat_until_shots_requested", bool)
         self.options.set_validator("transpile", bool)
 
+        # a list validator accepts both YieldHandling members and their names
+        self.options.set_validator("yield_handling", list(YieldHandling))
+
         if supported_qpu_strings := solver.properties.get("supported_qpu_strings"):
             self.options.set_validator("qpu", list(supported_qpu_strings))
 
@@ -132,6 +137,7 @@ class QCDLSimulatorBackend(BackendV2):
             label=None,
             pack_qcdls=True,
             qcdl_pack_target=0.4,
+            yield_handling=YieldHandling.only_post_selected_counts,
         )
 
     def _build_target(self) -> Target:
@@ -157,7 +163,10 @@ class QCDLSimulatorBackend(BackendV2):
             **options: Overrides of the backend's :attr:`options` for this run
                 (``shots``, ``time_limit``, ``repeat_until_shots_requested``,
                 ``transpile``, ``qpu``, ``noise_model``, ``label``,
-                ``pack_qcdls``, ``qcdl_pack_target``).
+                ``pack_qcdls``, ``qcdl_pack_target``, ``yield_handling``).
+                ``yield_handling``, a :class:`~dwave.gate.results.YieldHandling`
+                member or its name, selects how splats reported when running
+                with ``noise_model=True`` are resolved in the result counts.
 
         Returns:
             The job wrapping the submitted QCDL problems.
@@ -203,4 +212,10 @@ class QCDLSimulatorBackend(BackendV2):
             for qcdl in qcdls
         ]
 
-        return QCDLJob(backend=self, job_id=job_id, futures=futures, qcdls=qcdls)
+        return QCDLJob(
+            backend=self,
+            job_id=job_id,
+            futures=futures,
+            qcdls=qcdls,
+            yield_handling=YieldHandling.from_name(opts.yield_handling),
+        )

--- a/dwave/plugins/qiskit/leap/backend.py
+++ b/dwave/plugins/qiskit/leap/backend.py
@@ -1,0 +1,157 @@
+# Copyright 2026 D-Wave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qiskit backend for D-Wave Leap QCDL solvers."""
+
+from __future__ import annotations
+
+import copy
+import uuid
+from typing import TYPE_CHECKING
+
+from qiskit import QuantumCircuit
+from qiskit.circuit import Measure
+from qiskit.circuit.library.standard_gates import get_standard_gate_name_mapping
+from qiskit.providers import BackendV2, Options
+from qiskit.transpiler import Target
+
+from dwave.plugins.qiskit.leap.job import QCDLJob
+from dwave.plugins.qiskit.qcdl.translators import circuits_to_qcdls
+
+if TYPE_CHECKING:
+    from dwave.cloud.solver import QCDLSolver
+
+    from dwave.plugins.qiskit.leap.provider import DWaveProvider
+
+__all__ = ["QCDLBackend"]
+
+# gates the QCDL translators support that are also Qiskit standard gates
+# (the translator-only sy/sydg/mced have no Qiskit standard counterpart)
+_QCDL_STANDARD_GATE_NAMES = (
+    "x", "sx", "y", "z", "s", "sdg", "t", "tdg", "h",
+    "rx", "ry", "rz", "p", "u",
+    "swap", "cx", "cy", "cz", "crx", "cry", "crz", "cp", "cu",
+    "rxx", "ryy", "rzz",
+)
+
+
+class QCDLBackend(BackendV2):
+    """A Qiskit backend running circuits on a D-Wave Leap QCDL solver.
+
+    Args:
+        solver: The Leap QCDL solver the backend submits problems to.
+        provider: The provider the backend was obtained from.
+    """
+
+    def __init__(self, solver: QCDLSolver, provider: DWaveProvider | None = None):
+        super().__init__(
+            provider=provider,
+            name=solver.name,
+            description=f"D-Wave Leap QCDL solver {solver.name}",
+            backend_version=solver.properties.get("version"),
+        )
+        self._solver = solver
+        self._target: Target | None = None
+
+        max_shots = solver.properties.get("max_shots")
+        if max_shots:
+            self.options.set_validator("shots", (1, int(max_shots)))
+
+    @property
+    def solver(self) -> QCDLSolver:
+        """The Leap QCDL solver the backend submits problems to."""
+        return self._solver
+
+    @property
+    def target(self) -> Target:
+        if self._target is None:
+            self._target = self._build_target()
+        return self._target
+
+    @property
+    def max_circuits(self) -> None:
+        return None
+
+    @classmethod
+    def _default_options(cls) -> Options:
+        return Options(
+            shots=1024, time_limit=None, label=None, qcdl_pack_target=True)
+
+    def _build_target(self) -> Target:
+        target = Target(
+            description=f"Target for {self.name}",
+            # None means unconstrained (no qubit limit advertised by the solver)
+            num_qubits=self._solver.properties.get("num_qubits"),
+        )
+        gate_mapping = get_standard_gate_name_mapping()
+        for gate_name in _QCDL_STANDARD_GATE_NAMES:
+            # properties=None makes the instruction global (all-to-all)
+            target.add_instruction(gate_mapping[gate_name], properties=None, name=gate_name)
+        target.add_instruction(Measure(), properties=None, name="measure")
+        return target
+
+    def run(
+        self, run_input: QuantumCircuit | list[QuantumCircuit], **options
+    ) -> QCDLJob:
+        """Translate circuits to QCDL and submit them to the solver.
+
+        Args:
+            run_input: A circuit, or list of circuits, to run.
+            **options: Overrides of the backend's :attr:`options` for this run
+                (``shots``, ``time_limit``, ``label``, ``qcdl_pack_target``).
+
+        Returns:
+            The job wrapping the submitted QCDL problems.
+        """
+        if isinstance(run_input, QuantumCircuit):
+            circuits = [run_input]
+        elif isinstance(run_input, (list, tuple)) and all(
+            isinstance(circuit, QuantumCircuit) for circuit in run_input
+        ):
+            circuits = list(run_input)
+        else:
+            raise TypeError(
+                "run() accepts a QuantumCircuit or a list of QuantumCircuit, "
+                f"not {type(run_input).__name__}"
+            )
+
+        unknown = set(options) - set(self.options)
+        if unknown:
+            raise AttributeError(
+                f"options not valid for this backend: {', '.join(sorted(unknown))}"
+            )
+        opts = copy.deepcopy(self.options)
+        opts.update_options(**options)
+
+        job_id = uuid.uuid4().hex
+
+        params = {"shots": opts.shots}
+        if opts.time_limit is not None:
+            params["time_limit"] = opts.time_limit
+
+        qcdls = list(
+            circuits_to_qcdls(
+                circuits, job_id=job_id, qcdl_pack_target=opts.qcdl_pack_target
+            )
+        )
+        futures = [
+            self._solver.sample_qcdl(
+                qcdl.qcdl,
+                label=opts.label or f"qiskit:{job_id}:{qcdl.job_name}",
+                **params,
+            )
+            for qcdl in qcdls
+        ]
+
+        return QCDLJob(backend=self, job_id=job_id, futures=futures, qcdls=qcdls)

--- a/dwave/plugins/qiskit/leap/backend.py
+++ b/dwave/plugins/qiskit/leap/backend.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
     from dwave.plugins.qiskit.leap.provider import DWaveProvider
 
-__all__ = ["QCDLBackend"]
+__all__ = ["QCDLSimulatorBackend"]
 
 # gates the QCDL translators support that are also Qiskit standard gates
 # (the translator-only sy/sydg/mced have no Qiskit standard counterpart)
@@ -46,25 +46,29 @@ _QCDL_STANDARD_GATE_NAMES = (
 )
 
 
-class QCDLBackend(BackendV2):
-    """A Qiskit backend running circuits on a D-Wave Leap QCDL solver.
+class QCDLSimulatorBackend(BackendV2):
+    """A Qiskit backend running circuits on a D-Wave Leap QCDL simulator solver.
 
     Args:
-        solver: The Leap QCDL solver the backend submits problems to.
-        provider: The provider the backend was obtained from.
+        solver:
+            The Leap QCDL simulator solver the backend submits problems to.
+        provider:
+            The provider the backend was obtained from.
 
     Raises:
-        ValueError: If the solver is not a QCDL solver.
+        ValueError: If the solver is not a QCDL simulator solver.
     """
 
     def __init__(self, solver: QCDLSolver, provider: DWaveProvider | None = None):
+        if solver.properties.get("category") != "software-gate":
+            raise ValueError("selected solver is not a gate-model simulator")
         if 'qcdl' not in solver.supported_problem_types:
             raise ValueError("selected solver does not support the 'qcdl' problem type.")
 
         super().__init__(
             provider=provider,
             name=solver.name,
-            description=f"D-Wave Leap QCDL solver {solver.name}",
+            description=f"D-Wave Leap QCDL simulator solver {solver.name}",
             backend_version=solver.properties.get("version"),
         )
         self._solver = solver
@@ -76,7 +80,7 @@ class QCDLBackend(BackendV2):
 
     @property
     def solver(self) -> QCDLSolver:
-        """The Leap QCDL solver the backend submits problems to."""
+        """The Leap QCDL simulator solver the backend submits problems to."""
         return self._solver
 
     @property

--- a/dwave/plugins/qiskit/leap/backend.py
+++ b/dwave/plugins/qiskit/leap/backend.py
@@ -28,6 +28,7 @@ from qiskit import QuantumCircuit
 from qiskit.circuit import Measure
 from qiskit.circuit.library.standard_gates import get_standard_gate_name_mapping
 from qiskit.providers import BackendV2, Options
+from qiskit.result import MeasLevel
 from qiskit.transpiler import Target
 
 from dwave.plugins.qiskit.leap.job import QCDLJob
@@ -35,7 +36,6 @@ from dwave.plugins.qiskit.qcdl.translators import circuits_to_qcdls
 
 if TYPE_CHECKING:
     from dwave.cloud.solver import QCDLSolver
-
     from dwave.plugins.qiskit.leap.provider import DWaveProvider
 
 __all__ = ["QCDLSimulatorBackend"]
@@ -187,6 +187,15 @@ class QCDLSimulatorBackend(BackendV2):
                 "run() accepts a QuantumCircuit or an iterable of QuantumCircuit items, "
                 f"not {type(run_input).__name__}"
             )
+
+        # we only support MeasLevel.CLASSIFIED, so don't fail if explicitly specified
+        meas_level = options.pop('meas_level', None)
+        if meas_level is not None and meas_level != MeasLevel.CLASSIFIED:
+            raise RuntimeError(f"{meas_level=} is not supported by this backend")
+
+        # clarify the failure
+        if memory := options.pop('memory', None):
+            raise RuntimeError(f"{memory=} is not supported by this backend")
 
         unknown = set(options) - set(self.options)
         if unknown:

--- a/dwave/plugins/qiskit/leap/backend.py
+++ b/dwave/plugins/qiskit/leap/backend.py
@@ -52,9 +52,15 @@ class QCDLBackend(BackendV2):
     Args:
         solver: The Leap QCDL solver the backend submits problems to.
         provider: The provider the backend was obtained from.
+
+    Raises:
+        ValueError: If the solver is not a QCDL solver.
     """
 
     def __init__(self, solver: QCDLSolver, provider: DWaveProvider | None = None):
+        if 'qcdl' not in solver.supported_problem_types:
+            raise ValueError("selected solver does not support the 'qcdl' problem type.")
+
         super().__init__(
             provider=provider,
             name=solver.name,

--- a/dwave/plugins/qiskit/leap/backend.py
+++ b/dwave/plugins/qiskit/leap/backend.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import copy
 import uuid
+from collections.abc import Iterable
 from functools import cached_property
 from typing import Any, TYPE_CHECKING
 
@@ -154,13 +155,15 @@ class QCDLSimulatorBackend(BackendV2):
         return target
 
     def run(
-        self, run_input: QuantumCircuit | list[QuantumCircuit], **options
+        self, run_input: QuantumCircuit | Iterable[QuantumCircuit], **options
     ) -> QCDLJob:
         """Translate circuits to QCDL and submit them to the solver.
 
         Args:
-            run_input: A circuit, or list of circuits, to run.
-            **options: Overrides of the backend's :attr:`options` for this run
+            run_input:
+                A circuit, or an iterable of circuits, to run.
+            **options:
+                Overrides of the backend's :attr:`options` for this run
                 (``shots``, ``time_limit``, ``repeat_until_shots_requested``,
                 ``transpile``, ``qpu``, ``noise_model``, ``label``,
                 ``pack_qcdls``, ``qcdl_pack_target``, ``yield_handling``).
@@ -175,13 +178,13 @@ class QCDLSimulatorBackend(BackendV2):
 
         if isinstance(run_input, QuantumCircuit):
             circuits = [run_input]
-        elif isinstance(run_input, (list, tuple)) and all(
+        elif isinstance(run_input, Iterable) and all(
             isinstance(circuit, QuantumCircuit) for circuit in run_input
         ):
             circuits = list(run_input)
         else:
             raise TypeError(
-                "run() accepts a QuantumCircuit or a list of QuantumCircuit, "
+                "run() accepts a QuantumCircuit or an iterable of QuantumCircuit items, "
                 f"not {type(run_input).__name__}"
             )
 

--- a/dwave/plugins/qiskit/leap/backend.py
+++ b/dwave/plugins/qiskit/leap/backend.py
@@ -130,7 +130,8 @@ class QCDLSimulatorBackend(BackendV2):
             time_limit=1,
             transpile=True,
             label=None,
-            qcdl_pack_target=True,
+            pack_qcdls=True,
+            qcdl_pack_target=0.4,
         )
 
     def _build_target(self) -> Target:
@@ -156,7 +157,7 @@ class QCDLSimulatorBackend(BackendV2):
             **options: Overrides of the backend's :attr:`options` for this run
                 (``shots``, ``time_limit``, ``repeat_until_shots_requested``,
                 ``transpile``, ``qpu``, ``noise_model``, ``label``,
-                ``qcdl_pack_target``).
+                ``pack_qcdls``, ``qcdl_pack_target``).
 
         Returns:
             The job wrapping the submitted QCDL problems.
@@ -189,7 +190,8 @@ class QCDLSimulatorBackend(BackendV2):
 
         qcdls = list(
             circuits_to_qcdls(
-                circuits, job_id=job_id, qcdl_pack_target=opts.qcdl_pack_target
+                circuits, job_id=job_id, pack_qcdls=opts.pack_qcdls,
+                qcdl_pack_target=opts.qcdl_pack_target
             )
         )
         futures = [

--- a/dwave/plugins/qiskit/leap/backend.py
+++ b/dwave/plugins/qiskit/leap/backend.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 
 import copy
 import uuid
-from typing import TYPE_CHECKING
+from functools import cached_property
+from typing import Any, TYPE_CHECKING
 
 from qiskit import QuantumCircuit
 from qiskit.circuit import Measure
@@ -74,9 +75,24 @@ class QCDLSimulatorBackend(BackendV2):
         self._solver = solver
         self._target: Target | None = None
 
-        max_shots = solver.properties.get("max_shots")
-        if max_shots:
-            self.options.set_validator("shots", (1, int(max_shots)))
+        # update options with actual solver defaults
+        self._options.update_options(**self._solver_defaults)
+
+        # configure solver parameter validators
+        self.options.set_validator("noise_model", bool)
+        self.options.set_validator("repeat_until_shots_requested", bool)
+        self.options.set_validator("transpile", bool)
+
+        if supported_qpu_strings := solver.properties.get("supported_qpu_strings"):
+            self.options.set_validator("qpu", list(supported_qpu_strings))
+
+        min_shots = solver.properties.get("minimum_shots", 1)
+        max_shots = solver.properties.get("maximum_shots", 1_000_000)
+        self.options.set_validator("shots", (int(min_shots), int(max_shots)))
+
+        min_time_limit = solver.properties.get("minimum_time_limit_s", 1)
+        max_time_limit = solver.properties.get("maximum_time_limit_s", 2700)
+        self.options.set_validator("time_limit", (int(min_time_limit), int(max_time_limit)))
 
     @property
     def solver(self) -> QCDLSolver:
@@ -93,16 +109,35 @@ class QCDLSimulatorBackend(BackendV2):
     def max_circuits(self) -> None:
         return None
 
+    @cached_property
+    def _solver_defaults(self) -> dict[str, Any]:
+        """Default values of solver parameters."""
+        properties = self.solver.properties.copy()
+        defaults = {}
+        for param in self.solver.parameters:
+            default = properties.get(f"default_{param}", properties.get(f"default_{param}_s"))
+            if default is not None:
+                defaults[param] = default
+        return defaults
+
     @classmethod
     def _default_options(cls) -> Options:
         return Options(
-            shots=1024, time_limit=None, label=None, qcdl_pack_target=True)
+            noise_model=False,
+            qpu=None,
+            repeat_until_shots_requested=False,
+            shots=1,
+            time_limit=1,
+            transpile=True,
+            label=None,
+            qcdl_pack_target=True,
+        )
 
     def _build_target(self) -> Target:
         target = Target(
             description=f"Target for {self.name}",
             # None means unconstrained (no qubit limit advertised by the solver)
-            num_qubits=self._solver.properties.get("num_qubits"),
+            num_qubits=self._solver.properties.get("maximum_num_qubits"),
         )
         gate_mapping = get_standard_gate_name_mapping()
         for gate_name in _QCDL_STANDARD_GATE_NAMES:
@@ -119,11 +154,15 @@ class QCDLSimulatorBackend(BackendV2):
         Args:
             run_input: A circuit, or list of circuits, to run.
             **options: Overrides of the backend's :attr:`options` for this run
-                (``shots``, ``time_limit``, ``label``, ``qcdl_pack_target``).
+                (``shots``, ``time_limit``, ``repeat_until_shots_requested``,
+                ``transpile``, ``qpu``, ``noise_model``, ``label``,
+                ``qcdl_pack_target``).
 
         Returns:
             The job wrapping the submitted QCDL problems.
         """
+        # TODO: link to param docs once published.
+
         if isinstance(run_input, QuantumCircuit):
             circuits = [run_input]
         elif isinstance(run_input, (list, tuple)) and all(
@@ -146,9 +185,7 @@ class QCDLSimulatorBackend(BackendV2):
 
         job_id = uuid.uuid4().hex
 
-        params = {"shots": opts.shots}
-        if opts.time_limit is not None:
-            params["time_limit"] = opts.time_limit
+        params = {name: opts[name] for name in self.solver.parameters}
 
         qcdls = list(
             circuits_to_qcdls(

--- a/dwave/plugins/qiskit/leap/job.py
+++ b/dwave/plugins/qiskit/leap/job.py
@@ -1,0 +1,184 @@
+# Copyright 2026 D-Wave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qiskit job wrapping problems submitted to a D-Wave Leap QCDL solver."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from dwave.cloud.api.constants import ProblemStatus
+from dwave.cloud.exceptions import CanceledFutureError
+from dwave.gate.results import Result as GateResult
+
+from qiskit.providers import JobError, JobStatus, JobTimeoutError, JobV1
+from qiskit.result import Result
+from qiskit.result.models import ExperimentResult, ExperimentResultData
+
+from dwave.plugins.qiskit.qcdl.translators import QCDLWithMetadata, make_qiskit_counts
+
+if TYPE_CHECKING:
+    from dwave.cloud.computation import Future
+
+    from dwave.plugins.qiskit.leap.backend import QCDLBackend
+
+__all__ = ["QCDLJob"]
+
+_STATUS_MAP = {
+    ProblemStatus.PENDING.value: JobStatus.QUEUED,
+    ProblemStatus.IN_PROGRESS.value: JobStatus.RUNNING,
+    ProblemStatus.COMPLETED.value: JobStatus.DONE,
+    ProblemStatus.FAILED.value: JobStatus.ERROR,
+    ProblemStatus.CANCELLED.value: JobStatus.CANCELLED,
+}
+
+
+def _future_status(future: Future) -> JobStatus:
+    """Map a cloud-client future's state onto a Qiskit job status."""
+    if future.done():
+        try:
+            # Future.exception() raises the stored exception, if any
+            future.exception()
+        except CanceledFutureError:
+            return JobStatus.CANCELLED
+        except Exception:
+            return JobStatus.ERROR
+        if future.remote_status == ProblemStatus.CANCELLED.value:
+            return JobStatus.CANCELLED
+        return JobStatus.DONE
+
+    # remote_status is None until the first status poll comes back
+    return _STATUS_MAP.get(future.remote_status, JobStatus.INITIALIZING)
+
+
+def _per_circuit_metadata(qcdl: QCDLWithMetadata) -> list[QCDLWithMetadata]:
+    """List the per-circuit metadata entries of a translated QCDL, in circuit order."""
+    if qcdl.clbit_to_tag is not None:
+        # a single-circuit QCDL carries its own (per-circuit) metadata
+        return [qcdl]
+    return qcdl.circuit_metadata
+
+
+class QCDLJob(JobV1):
+    """A Qiskit job for circuits submitted to a D-Wave Leap QCDL solver.
+
+    A single job may span multiple QCDL problems when the circuits given to
+    :meth:`.QCDLBackend.run` are translated into more than one QCDL program.
+
+    Args:
+        backend: The backend the job was submitted through.
+        job_id: A unique identifier for the job.
+        futures: The in-flight cloud-client problems, one per QCDL program.
+        qcdls: The translated QCDL programs, positionally matching ``futures``.
+    """
+
+    _async = True
+
+    def __init__(
+        self,
+        backend: QCDLBackend,
+        job_id: str,
+        futures: list[Future],
+        qcdls: list[QCDLWithMetadata],
+    ):
+        super().__init__(backend, job_id)
+        self._futures = futures
+        self._qcdls = qcdls
+        self._result: Result | None = None
+
+    def submit(self) -> None:
+        """Unsupported; problems are submitted when the job is created by ``run()``."""
+        raise JobError("job has already been submitted")
+
+    def status(self) -> JobStatus:
+        """Return the aggregate status of all the job's QCDL problems."""
+        statuses = [_future_status(future) for future in self._futures]
+        for status in (JobStatus.ERROR, JobStatus.CANCELLED):
+            if status in statuses:
+                return status
+        if all(status is JobStatus.DONE for status in statuses):
+            return JobStatus.DONE
+        for status in (JobStatus.RUNNING, JobStatus.QUEUED):
+            if status in statuses:
+                return status
+        return JobStatus.INITIALIZING
+
+    def cancel(self) -> None:
+        """Request cancellation of all the job's QCDL problems.
+
+        Cancellation is best-effort; check :meth:`status` for the outcome.
+        """
+        for future in self._futures:
+            future.cancel()
+
+    def result(self, timeout: float | None = None) -> Result:
+        """Wait for all the job's QCDL problems and assemble their results.
+
+        Args:
+            timeout: Total number of seconds to wait for the results.
+
+        Returns:
+            A :class:`~qiskit.result.Result` with one experiment per submitted
+            circuit, in submission order.
+
+        Raises:
+            JobTimeoutError: If the results don't arrive within ``timeout``.
+            JobError: If any of the QCDL problems failed or was cancelled.
+        """
+        if self._result is None:
+            self._result = self._build_result(timeout=timeout)
+        return self._result
+
+    def _build_result(self, timeout: float | None) -> Result:
+        deadline = None if timeout is None else time.monotonic() + timeout
+        experiments = []
+
+        for future, qcdl in zip(self._futures, self._qcdls):
+            remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+            if not future.wait(timeout=remaining):
+                raise JobTimeoutError(
+                    f"timed out waiting for results of QCDL problem {future.id!r}"
+                )
+            try:
+                future.exception()
+            except Exception as exc:
+                raise JobError(f"QCDL problem {future.id!r} failed: {exc}") from exc
+
+            answer = future.answer_data
+            answer.seek(0)
+            gate_result = GateResult.model_validate_json(answer.read())
+
+            for metadata in _per_circuit_metadata(qcdl):
+                experiments.append(
+                    ExperimentResult(
+                        shots=gate_result.num_shots,
+                        success=True,
+                        data=ExperimentResultData(
+                            counts=make_qiskit_counts(gate_result, metadata)
+                        ),
+                        header=metadata.qiskit_header,
+                    )
+                )
+
+        return Result(
+            backend_name=self.backend().name,
+            backend_version=self.backend().backend_version,
+            job_id=self.job_id(),
+            success=True,
+            results=experiments,
+            date=datetime.now(timezone.utc).isoformat(),
+            status="COMPLETED",
+        )

--- a/dwave/plugins/qiskit/leap/job.py
+++ b/dwave/plugins/qiskit/leap/job.py
@@ -33,7 +33,7 @@ from dwave.plugins.qiskit.qcdl.translators import QCDLWithMetadata, make_qiskit_
 if TYPE_CHECKING:
     from dwave.cloud.computation import Future
 
-    from dwave.plugins.qiskit.leap.backend import QCDLBackend
+    from dwave.plugins.qiskit.leap.backend import QCDLSimulatorBackend
 
 __all__ = ["QCDLJob"]
 
@@ -76,7 +76,8 @@ class QCDLJob(JobV1):
     """A Qiskit job for circuits submitted to a D-Wave Leap QCDL solver.
 
     A single job may span multiple QCDL problems when the circuits given to
-    :meth:`.QCDLBackend.run` are translated into more than one QCDL program.
+    :meth:`.QCDLSimulatorBackend.run` are translated into more than one QCDL
+    program.
 
     Args:
         backend: The backend the job was submitted through.
@@ -89,7 +90,7 @@ class QCDLJob(JobV1):
 
     def __init__(
         self,
-        backend: QCDLBackend,
+        backend: QCDLSimulatorBackend,
         job_id: str,
         futures: list[Future],
         qcdls: list[QCDLWithMetadata],

--- a/dwave/plugins/qiskit/leap/job.py
+++ b/dwave/plugins/qiskit/leap/job.py
@@ -178,8 +178,18 @@ class QCDLJob(JobV1):
                             counts=counts,
                             raw_counts=raw_counts,
                             post_selection_yield=post_selection_yield,
+                            yield_handling=self._yield_handling,
+                            metadata={
+                                **metadata.qiskit_header,
+                                **metadata.circuit_metadata,
+                            }
                         ),
-                        header=metadata.qiskit_header,
+                        header={
+                            **metadata.qiskit_header,
+                            "metadata": {
+                                **metadata.circuit_metadata,
+                            },
+                        }
                     )
                 )
 

--- a/dwave/plugins/qiskit/leap/job.py
+++ b/dwave/plugins/qiskit/leap/job.py
@@ -22,12 +22,12 @@ from typing import TYPE_CHECKING
 
 from dwave.cloud.api.constants import ProblemStatus
 from dwave.cloud.exceptions import CanceledFutureError
-from dwave.gate.results import Result as GateResult
+from dwave.gate.results import Result as GateResult, YieldHandling
 
 from qiskit.providers import JobError, JobStatus, JobTimeoutError, JobV1
-from qiskit.result import Result
 from qiskit.result.models import ExperimentResult, ExperimentResultData
 
+from dwave.plugins.qiskit.leap.result import QCDLResult
 from dwave.plugins.qiskit.qcdl.translators import QCDLWithMetadata, make_qiskit_counts
 
 if TYPE_CHECKING:
@@ -84,6 +84,7 @@ class QCDLJob(JobV1):
         job_id: A unique identifier for the job.
         futures: The in-flight cloud-client problems, one per QCDL program.
         qcdls: The translated QCDL programs, positionally matching ``futures``.
+        yield_handling: Strategy used to resolve splats in the result counts.
     """
 
     _async = True
@@ -94,11 +95,13 @@ class QCDLJob(JobV1):
         job_id: str,
         futures: list[Future],
         qcdls: list[QCDLWithMetadata],
+        yield_handling: YieldHandling = YieldHandling.only_post_selected_counts,
     ):
         super().__init__(backend, job_id)
         self._futures = futures
         self._qcdls = qcdls
-        self._result: Result | None = None
+        self._yield_handling = YieldHandling.from_name(yield_handling)
+        self._result: QCDLResult | None = None
 
     def submit(self) -> None:
         """Unsupported; problems are submitted when the job is created by ``run()``."""
@@ -125,15 +128,17 @@ class QCDLJob(JobV1):
         for future in self._futures:
             future.cancel()
 
-    def result(self, timeout: float | None = None) -> Result:
+    def result(self, timeout: float | None = None) -> QCDLResult:
         """Wait for all the job's QCDL problems and assemble their results.
 
         Args:
             timeout: Total number of seconds to wait for the results.
 
         Returns:
-            A :class:`~qiskit.result.Result` with one experiment per submitted
-            circuit, in submission order.
+            A :class:`.QCDLResult` with one experiment per submitted circuit,
+            in submission order. Each experiment's counts have splats resolved
+            per the job's ``yield_handling``; the unresolved counts are kept in
+            the experiment data as ``raw_counts``.
 
         Raises:
             JobTimeoutError: If the results don't arrive within ``timeout``.
@@ -143,7 +148,7 @@ class QCDLJob(JobV1):
             self._result = self._build_result(timeout=timeout)
         return self._result
 
-    def _build_result(self, timeout: float | None) -> Result:
+    def _build_result(self, timeout: float | None) -> QCDLResult:
         deadline = None if timeout is None else time.monotonic() + timeout
         experiments = []
 
@@ -163,18 +168,22 @@ class QCDLJob(JobV1):
             gate_result = GateResult.model_validate_json(answer.read())
 
             for metadata in _per_circuit_metadata(qcdl):
+                raw_counts = make_qiskit_counts(gate_result, metadata)
+                counts, post_selection_yield = self._yield_handling.apply(raw_counts)
                 experiments.append(
                     ExperimentResult(
                         shots=gate_result.num_shots,
                         success=True,
                         data=ExperimentResultData(
-                            counts=make_qiskit_counts(gate_result, metadata)
+                            counts=counts,
+                            raw_counts=raw_counts,
+                            post_selection_yield=post_selection_yield,
                         ),
                         header=metadata.qiskit_header,
                     )
                 )
 
-        return Result(
+        return QCDLResult(
             backend_name=self.backend().name,
             backend_version=self.backend().backend_version,
             job_id=self.job_id(),

--- a/dwave/plugins/qiskit/leap/job.py
+++ b/dwave/plugins/qiskit/leap/job.py
@@ -179,16 +179,10 @@ class QCDLJob(JobV1):
                             raw_counts=raw_counts,
                             post_selection_yield=post_selection_yield,
                             yield_handling=self._yield_handling,
-                            metadata={
-                                **metadata.qiskit_header,
-                                **metadata.circuit_metadata,
-                            }
                         ),
                         header={
                             **metadata.qiskit_header,
-                            "metadata": {
-                                **metadata.circuit_metadata,
-                            },
+                            "metadata": dict(metadata.circuit_metadata),
                         }
                     )
                 )

--- a/dwave/plugins/qiskit/leap/provider.py
+++ b/dwave/plugins/qiskit/leap/provider.py
@@ -63,29 +63,30 @@ class DWaveProvider:
     def backends(self, name: str | None = None, **kwargs) -> list[QCDLSimulatorBackend]:
         """List all QCDL simulator backends available on Leap.
 
-        Backends are listed newest solver first.
+        Backends are by default listed newest solver first, but the order can be
+        overridden with the ``order_by`` keyword argument.
 
         Args:
             name:
                 If given, only the backend (solver) with this name is returned.
             **kwargs:
-                Backend attribute filters, matched against backends'
-                configuration and status.
+                Backend attribute filters, matched against solver properties.
+                See :meth:`~dwave.cloud.client.Client.get_solvers`.
 
         Returns:
             The matching backends.
         """
-        filters = dict(
+        filters = kwargs | dict(
             supported_problem_types__contains="qcdl",
             category="software-gate",
-            order_by="-properties.version",
         )
+        filters.setdefault("order_by", "-properties.version")
         if name is not None:
             filters["name"] = name
+
         solvers = self._get_client().get_solvers(**filters)
 
-        backends = [QCDLSimulatorBackend(solver, provider=self) for solver in solvers]
-        return filter_backends(backends, **kwargs)
+        return [QCDLSimulatorBackend(solver, provider=self) for solver in solvers]
 
     def get_backend(self, name: str | None = None, **kwargs) -> QCDLSimulatorBackend:
         """Return a single QCDL simulator backend matching the specified filtering.
@@ -94,8 +95,10 @@ class DWaveProvider:
         version is returned.
 
         Args:
-            name: Name of the backend (solver).
-            **kwargs: Backend attribute filters, as for :meth:`backends`.
+            name:
+                Name of the backend (solver).
+            **kwargs:
+                Backend attribute filters, as for :meth:`backends`.
 
         Returns:
             The matching backend.

--- a/dwave/plugins/qiskit/leap/provider.py
+++ b/dwave/plugins/qiskit/leap/provider.py
@@ -66,8 +66,10 @@ class DWaveProvider:
         Backends are listed newest solver first.
 
         Args:
-            name: If given, only the backend (solver) with this name.
-            **kwargs: Backend attribute filters, matched against backends'
+            name:
+                If given, only the backend (solver) with this name is returned.
+            **kwargs:
+                Backend attribute filters, matched against backends'
                 configuration and status.
 
         Returns:
@@ -103,7 +105,9 @@ class DWaveProvider:
         """
         backends = self.backends(name, **kwargs)
         if not backends:
-            raise QiskitBackendNotFoundError("no backend matches the criteria")
+            raise QiskitBackendNotFoundError(
+                "no backend matches the provider configuration and/or backend filters"
+            )
         return backends[0]
 
     def close(self) -> None:

--- a/dwave/plugins/qiskit/leap/provider.py
+++ b/dwave/plugins/qiskit/leap/provider.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from dwave.cloud import Client
+from dwave.cloud.exceptions import SolverNotFoundError
 
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.providers.providerutils import filter_backends
@@ -84,7 +85,11 @@ class DWaveProvider:
         if name is not None:
             filters["name"] = name
 
-        solvers = self._get_client().get_solvers(**filters)
+        try:
+            solvers = self._get_client().get_solvers(**filters)
+        except SolverNotFoundError:
+            # note: get_solvers raises SolverNotFoundError only when named solver not found
+            solvers = []
 
         return [QCDLSimulatorBackend(solver, provider=self) for solver in solvers]
 

--- a/dwave/plugins/qiskit/leap/provider.py
+++ b/dwave/plugins/qiskit/leap/provider.py
@@ -1,0 +1,110 @@
+# Copyright 2026 D-Wave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qiskit provider exposing D-Wave Leap QCDL solvers as backends."""
+
+from __future__ import annotations
+
+from dwave.cloud import Client
+
+from qiskit.providers.exceptions import QiskitBackendNotFoundError
+from qiskit.providers.providerutils import filter_backends
+
+from dwave.plugins.qiskit.leap.backend import QCDLBackend
+
+__all__ = ["DWaveProvider"]
+
+
+class DWaveProvider:
+    """A Qiskit provider for D-Wave Leap quantum gate model (QCDL) solvers.
+
+    Credentials and connection parameters follow the standard
+    ``dwave-cloud-client`` configuration: values given here take precedence
+    over environment variables, which take precedence over the configuration
+    file.
+
+    Args:
+        **config:
+            :class:`~dwave.cloud.Client` configuration options passed to
+            :meth:`~dwave.cloud.client.Client.from_config`.
+
+    Examples:
+        >>> from dwave.plugins.qiskit import DWaveProvider
+        >>> with DWaveProvider() as provider:      # doctest: +SKIP
+        ...     backend = provider.get_backend()
+    """
+
+    def __init__(self, **config):
+        self._config = config
+        self._client: Client | None = None
+
+    def _get_client(self) -> Client:
+        if self._client is None:
+            self._client = Client.from_config(client="base", **self._config)
+        return self._client
+
+    def backends(self, name: str | None = None, **kwargs) -> list[QCDLBackend]:
+        """List QCDL backends available on Leap.
+
+        Args:
+            name: If given, only the backend (solver) with this name.
+            **kwargs: Backend attribute filters, matched against backends'
+                configuration and status.
+
+        Returns:
+            The matching backends.
+        """
+        filters = {"supported_problem_types__contains": "qcdl"}
+        if name is not None:
+            filters["name"] = name
+        solvers = self._get_client().get_solvers(**filters)
+        backends = [QCDLBackend(solver, provider=self) for solver in solvers]
+        return filter_backends(backends, **kwargs)
+
+    def get_backend(self, name: str | None = None, **kwargs) -> QCDLBackend:
+        """Return a single QCDL backend matching the specified filtering.
+
+        Args:
+            name: Name of the backend (solver).
+            **kwargs: Backend attribute filters, as for :meth:`backends`.
+
+        Returns:
+            The matching backend.
+
+        Raises:
+            QiskitBackendNotFoundError: If no backend, or more than one
+                backend, matches the filtering.
+        """
+        backends = self.backends(name, **kwargs)
+        if len(backends) == 1:
+            return backends[0]
+        if not backends:
+            raise QiskitBackendNotFoundError("no backend matches the criteria")
+        raise QiskitBackendNotFoundError("more than one backend matches the criteria")
+
+    def close(self) -> None:
+        """Release the cloud client's resources.
+
+        Backends and jobs obtained from this provider stop working once the
+        provider is closed.
+        """
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self) -> DWaveProvider:
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.close()

--- a/dwave/plugins/qiskit/leap/provider.py
+++ b/dwave/plugins/qiskit/leap/provider.py
@@ -37,7 +37,8 @@ class DWaveProvider:
     Args:
         **config:
             :class:`~dwave.cloud.Client` configuration options passed to
-            :meth:`~dwave.cloud.client.Client.from_config`.
+            :meth:`~dwave.cloud.client.Client.from_config`, e.g. ``config_file``
+            or ``profile``.
 
     Examples:
         >>> from dwave.plugins.qiskit import DWaveProvider
@@ -46,16 +47,23 @@ class DWaveProvider:
     """
 
     def __init__(self, **config):
+        # default to the base client, but allow override
+        config.setdefault("client", "base")
+        # default to short-lived session to prevent resets on slow uploads
+        config.setdefault("connection_close", True)
+
         self._config = config
         self._client: Client | None = None
 
     def _get_client(self) -> Client:
         if self._client is None:
-            self._client = Client.from_config(client="base", **self._config)
+            self._client = Client.from_config(**self._config)
         return self._client
 
     def backends(self, name: str | None = None, **kwargs) -> list[QCDLBackend]:
         """List QCDL backends available on Leap.
+
+        Backends are listed newest solver first.
 
         Args:
             name: If given, only the backend (solver) with this name.
@@ -65,7 +73,10 @@ class DWaveProvider:
         Returns:
             The matching backends.
         """
-        filters = {"supported_problem_types__contains": "qcdl"}
+        filters = dict(
+            supported_problem_types__contains="qcdl",
+            order_by="-properties.version",
+        )
         if name is not None:
             filters["name"] = name
         solvers = self._get_client().get_solvers(**filters)
@@ -75,6 +86,9 @@ class DWaveProvider:
     def get_backend(self, name: str | None = None, **kwargs) -> QCDLBackend:
         """Return a single QCDL backend matching the specified filtering.
 
+        When more than one backend matches, the one with the newest solver
+        version is returned.
+
         Args:
             name: Name of the backend (solver).
             **kwargs: Backend attribute filters, as for :meth:`backends`.
@@ -83,15 +97,12 @@ class DWaveProvider:
             The matching backend.
 
         Raises:
-            QiskitBackendNotFoundError: If no backend, or more than one
-                backend, matches the filtering.
+            QiskitBackendNotFoundError: If no backend matches the filtering.
         """
         backends = self.backends(name, **kwargs)
-        if len(backends) == 1:
-            return backends[0]
         if not backends:
             raise QiskitBackendNotFoundError("no backend matches the criteria")
-        raise QiskitBackendNotFoundError("more than one backend matches the criteria")
+        return backends[0]
 
     def close(self) -> None:
         """Release the cloud client's resources.

--- a/dwave/plugins/qiskit/leap/provider.py
+++ b/dwave/plugins/qiskit/leap/provider.py
@@ -21,7 +21,7 @@ from dwave.cloud import Client
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.providers.providerutils import filter_backends
 
-from dwave.plugins.qiskit.leap.backend import QCDLBackend
+from dwave.plugins.qiskit.leap.backend import QCDLSimulatorBackend
 
 __all__ = ["DWaveProvider"]
 
@@ -60,8 +60,8 @@ class DWaveProvider:
             self._client = Client.from_config(**self._config)
         return self._client
 
-    def backends(self, name: str | None = None, **kwargs) -> list[QCDLBackend]:
-        """List QCDL backends available on Leap.
+    def backends(self, name: str | None = None, **kwargs) -> list[QCDLSimulatorBackend]:
+        """List all QCDL simulator backends available on Leap.
 
         Backends are listed newest solver first.
 
@@ -75,16 +75,18 @@ class DWaveProvider:
         """
         filters = dict(
             supported_problem_types__contains="qcdl",
+            category="software-gate",
             order_by="-properties.version",
         )
         if name is not None:
             filters["name"] = name
         solvers = self._get_client().get_solvers(**filters)
-        backends = [QCDLBackend(solver, provider=self) for solver in solvers]
+
+        backends = [QCDLSimulatorBackend(solver, provider=self) for solver in solvers]
         return filter_backends(backends, **kwargs)
 
-    def get_backend(self, name: str | None = None, **kwargs) -> QCDLBackend:
-        """Return a single QCDL backend matching the specified filtering.
+    def get_backend(self, name: str | None = None, **kwargs) -> QCDLSimulatorBackend:
+        """Return a single QCDL simulator backend matching the specified filtering.
 
         When more than one backend matches, the one with the newest solver
         version is returned.

--- a/dwave/plugins/qiskit/leap/result.py
+++ b/dwave/plugins/qiskit/leap/result.py
@@ -1,0 +1,94 @@
+# Copyright 2026 D-Wave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qiskit result for jobs run on a D-Wave Leap QCDL solver."""
+
+from __future__ import annotations
+
+from dwave.gate.results import YieldHandling
+
+from qiskit.exceptions import QiskitError
+from qiskit.result import Counts, Result
+
+__all__ = ["QCDLResult"]
+
+
+class QCDLResult(Result):
+    """A Qiskit result aware of splats in QCDL solver measurements.
+
+    When a circuit runs with ``noise_model=True``, a measurement in which an
+    error was detected is reported as a ``"*"`` (splat) instead of a bit value.
+    Qiskit cannot represent splats in counts, so they are resolved with a
+    :class:`~dwave.gate.results.YieldHandling` strategy: the counts stored in
+    each experiment's ``data`` were resolved with the strategy the job ran
+    with, while the unresolved counts are kept in ``data`` as ``raw_counts``
+    (with the observed yield as ``post_selection_yield``).
+    """
+
+    def get_counts(
+        self, experiment=None, yield_handling: YieldHandling | str | None = None
+    ) -> Counts | list[Counts]:
+        """Get the histogram data of an experiment, with splats resolved.
+
+        Args:
+            experiment: The experiment, as in
+                :meth:`qiskit.result.Result.get_counts`.
+            yield_handling: Strategy (or its name) used to re-resolve splats
+                in the raw counts. Defaults to the counts already resolved
+                with the strategy the job ran with.
+
+        Returns:
+            One counts dict per selected experiment. Note that counts are
+            floats for the ``renormalize_distribution*`` strategies, and that
+            keys contain splats for ``ignore_splats``.
+        """
+        if experiment is None:
+            exp_keys = range(len(self.results))
+        else:
+            exp_keys = [experiment]
+
+        counts_list = []
+        for key in exp_keys:
+            exp = self._get_experiment(key)
+            try:
+                header = exp.header
+            except (AttributeError, QiskitError):
+                header = None
+
+            data = self.data(key)
+            if yield_handling is None:
+                counts = data["counts"]
+            else:
+                counts, _ = YieldHandling.from_name(yield_handling).apply(
+                    data["raw_counts"]
+                )
+
+            counts_header = {}
+            if header:
+                counts_header = {
+                    k: v
+                    for k, v in header.items()
+                    if k in {"time_taken", "creg_sizes", "memory_slots"}
+                }
+            if any("*" in bitstring for bitstring in counts):
+                # splat keys can't be reformatted via creg_sizes/memory_slots,
+                # but they are already register-formatted, so keep them as-is
+                counts_header.pop("creg_sizes", None)
+                counts_header.pop("memory_slots", None)
+
+            counts_list.append(Counts(counts, **counts_header))
+
+        if len(counts_list) == 1:
+            return counts_list[0]
+        return counts_list

--- a/dwave/plugins/qiskit/leap/result.py
+++ b/dwave/plugins/qiskit/leap/result.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from dwave.gate.results import YieldHandling
 
+from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.exceptions import QiskitError
 from qiskit.result import Counts, Result
 
@@ -31,19 +32,21 @@ class QCDLResult(Result):
     error was detected is reported as a ``"*"`` (splat) instead of a bit value.
     Qiskit cannot represent splats in counts, so they are resolved with a
     :class:`~dwave.gate.results.YieldHandling` strategy: the counts stored in
-    each experiment's ``data`` were resolved with the strategy the job ran
+    each experiment's ``data`` are resolved with the strategy the job ran
     with, while the unresolved counts are kept in ``data`` as ``raw_counts``
     (with the observed yield as ``post_selection_yield``).
     """
 
     def get_counts(
-        self, experiment=None, yield_handling: YieldHandling | str | None = None
+        self,
+        experiment: str | QuantumCircuit | int | None = None,
+        yield_handling: YieldHandling | str | None = None,
     ) -> Counts | list[Counts]:
         """Get the histogram data of an experiment, with splats resolved.
 
         Args:
-            experiment: The experiment, as in
-                :meth:`qiskit.result.Result.get_counts`.
+            experiment: the index of the experiment, as specified by
+                ``data([experiment])``. See: :meth:`qiskit.result.Result.get_counts`.
             yield_handling: Strategy (or its name) used to re-resolve splats
                 in the raw counts. Defaults to the counts already resolved
                 with the strategy the job ran with.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "qiskit-optimization>=0.7",
     "dwave-system>=1.20",
     "dwave-gate>=0.5.0",
+    "dwave-cloud-client>=0.14.7",
 ]
 
 [project.urls]
@@ -41,6 +42,7 @@ dev = [
     "qiskit-optimization==0.7.0",
     "dwave-system==1.35.0",
     "dwave-gate==0.5.0",
+    "dwave-cloud-client==0.14.7",
     {include-group = "changelog"},
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "qiskit>=1.0",
+    "qiskit>=2",
     "qiskit-optimization>=0.7",
     "dwave-system>=1.20",
     "dwave-gate>=0.5.0",

--- a/releasenotes/notes/leap-qcdl-provider-a3233aa960471bc0.yaml
+++ b/releasenotes/notes/leap-qcdl-provider-a3233aa960471bc0.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Add ``DWaveProvider``, a Qiskit provider that exposes D-Wave Leap
+    quantum gate model (QCDL) solvers as Qiskit backends.
+  - |
+    Add ``QCDLBackend`` and ``QCDLJob``, a ``BackendV2``/``JobV1``
+    implementation that translates circuits to QCDL, submits them to a Leap
+    QCDL solver, and assembles solver answers into a standard
+    ``qiskit.result.Result``.

--- a/releasenotes/notes/leap-qcdl-provider-a3233aa960471bc0.yaml
+++ b/releasenotes/notes/leap-qcdl-provider-a3233aa960471bc0.yaml
@@ -4,7 +4,14 @@ features:
     Add ``DWaveProvider``, a Qiskit provider that exposes D-Wave Leap
     quantum gate model (QCDL) solvers as Qiskit backends.
   - |
-    Add ``QCDLBackend`` and ``QCDLJob``, a ``BackendV2``/``JobV1``
+    Add ``QCDLSimulatorBackend`` and ``QCDLJob``, a ``BackendV2``/``JobV1``
     implementation that translates circuits to QCDL, submits them to a Leap
-    QCDL solver, and assembles solver answers into a standard
-    ``qiskit.result.Result``.
+    QCDL solver, and assembles solver answers into a ``QCDLResult``, a
+    ``qiskit.result.Result`` subclass.
+  - |
+    Add a ``yield_handling`` backend option that selects the
+    ``dwave.gate.results.YieldHandling`` strategy used to resolve splats
+    (measurements marked as errored when running with ``noise_model=True``)
+    in the result counts, defaulting to post-selection. ``QCDLResult`` keeps
+    the unresolved counts in each experiment's data as ``raw_counts`` and
+    lets ``get_counts()`` re-resolve them with a different strategy.

--- a/tests/test_leap.py
+++ b/tests/test_leap.py
@@ -1,0 +1,430 @@
+# Copyright 2026 D-Wave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import json
+import unittest.mock as mock
+
+import pytest
+
+from dwave.cloud.exceptions import (
+    CanceledFutureError,
+    ConfigFileError,
+    SolverError,
+    SolverFailureError,
+)
+from dwave.cloud.solver import QCDLSolver
+from dwave.cloud.testing.mocks import qcdl_solver_data
+
+from qiskit import QuantumCircuit
+from qiskit.providers import JobError, JobStatus, JobTimeoutError
+from qiskit.providers.exceptions import QiskitBackendNotFoundError
+
+from dwave.plugins.qiskit import DWaveProvider
+from dwave.plugins.qiskit.leap import QCDLBackend, QCDLJob
+from dwave.plugins.qiskit.leap.backend import _QCDL_STANDARD_GATE_NAMES
+from dwave.plugins.qiskit.leap.job import _future_status
+
+
+def make_solver(**kwargs) -> QCDLSolver:
+    return QCDLSolver(client=mock.Mock(), data=qcdl_solver_data(**kwargs))
+
+
+def make_answer(num_shots: int, tag_to_bits: dict[str, tuple[int, list[str]]],
+                num_qubits: int) -> dict:
+    """Fabricate a decoded QCDL solver answer.
+
+    Args:
+        num_shots: Number of shots.
+        tag_to_bits: Maps a measurement tag to the measured qubit's index and
+            its per-shot values.
+        num_qubits: Total number of qubits in the QCDL program.
+
+    Returns:
+        The answer dict, serializable to the solver answer JSON.
+    """
+    measurements = {}
+    for tag, (qubit, bits) in tag_to_bits.items():
+        per_qubit: list[list[str]] = [[] for _ in range(num_qubits)]
+        per_qubit[qubit] = bits
+        measurements[tag] = per_qubit
+    return {"num_shots": num_shots, "measurements": measurements}
+
+
+class StubFuture:
+    """Minimal stand-in for :class:`dwave.cloud.computation.Future`."""
+
+    def __init__(self, *, answer: dict | None = None, remote_status: str | None = None,
+                 done: bool = False, exc: Exception | None = None, id: str = "problem-1"):
+        self.id = id
+        self.label = None
+        self.remote_status = remote_status
+        self._done = done
+        self._exc = exc
+        self._answer = answer
+        self.cancel_called = False
+
+    def done(self) -> bool:
+        return self._done
+
+    def wait(self, timeout: float | None = None) -> bool:
+        return self._done
+
+    def cancel(self) -> None:
+        self.cancel_called = True
+
+    def exception(self) -> None:
+        if self._exc is not None:
+            raise self._exc
+
+    @property
+    def answer_data(self) -> io.BytesIO:
+        return io.BytesIO(json.dumps(self._answer).encode())
+
+
+def done_future(answer: dict, **kwargs) -> StubFuture:
+    return StubFuture(answer=answer, done=True, remote_status="COMPLETED", **kwargs)
+
+
+def patch_sample_qcdl(monkeypatch, solver: QCDLSolver, futures: list[StubFuture]) -> list:
+    """Replace ``solver.sample_qcdl`` with a recorder returning canned futures."""
+    calls = []
+    futures_iter = iter(futures)
+
+    def sample_qcdl(qcdl, label=None, **params):
+        calls.append({"qcdl": qcdl, "label": label, "params": params})
+        return next(futures_iter)
+
+    monkeypatch.setattr(solver, "sample_qcdl", sample_qcdl)
+    return calls
+
+
+def bell_circuit(name: str = "bell") -> QuantumCircuit:
+    circuit = QuantumCircuit(2, 2, name=name)
+    circuit.h(0)
+    circuit.cx(0, 1)
+    circuit.measure([0, 1], [0, 1])
+    return circuit
+
+
+# provider
+
+
+def test_provider_lists_qcdl_backends():
+    client = mock.Mock()
+    client.get_solvers.return_value = [make_solver()]
+
+    with mock.patch("dwave.plugins.qiskit.leap.provider.Client") as client_cls:
+        client_cls.from_config.return_value = client
+        provider = DWaveProvider(token="secret")
+
+        client_cls.from_config.assert_not_called()  # client is created lazily
+
+        backends = provider.backends()
+
+    client_cls.from_config.assert_called_once()
+    call_kwargs = client_cls.from_config.call_args.kwargs
+    assert call_kwargs["client"] == "base"
+    assert call_kwargs["token"] == "secret"
+    assert client.get_solvers.call_args.kwargs["supported_problem_types__contains"] == "qcdl"
+
+    assert len(backends) == 1
+    assert isinstance(backends[0], QCDLBackend)
+    assert backends[0].name == "qcdl_mock_solver"
+    assert backends[0].provider is provider
+
+
+def test_provider_backends_name_filter():
+    client = mock.Mock()
+    client.get_solvers.return_value = []
+
+    with mock.patch("dwave.plugins.qiskit.leap.provider.Client") as client_cls:
+        client_cls.from_config.return_value = client
+        DWaveProvider().backends(name="some_solver")
+
+    assert client.get_solvers.call_args.kwargs["name"] == "some_solver"
+
+
+@pytest.mark.parametrize("num_solvers", [0, 2])
+def test_get_backend_requires_single_match(num_solvers):
+    client = mock.Mock()
+    client.get_solvers.return_value = [make_solver() for _ in range(num_solvers)]
+
+    with mock.patch("dwave.plugins.qiskit.leap.provider.Client") as client_cls:
+        client_cls.from_config.return_value = client
+        with pytest.raises(QiskitBackendNotFoundError):
+            DWaveProvider().get_backend()
+
+
+def test_provider_context_manager_closes_client():
+    client = mock.Mock()
+    client.get_solvers.return_value = []
+
+    with mock.patch("dwave.plugins.qiskit.leap.provider.Client") as client_cls:
+        client_cls.from_config.return_value = client
+        with DWaveProvider() as provider:
+            provider.backends()
+        client.close.assert_called_once()
+
+        # a closed provider creates a fresh client on next use
+        provider.backends()
+        assert client_cls.from_config.call_count == 2
+
+
+# backend
+
+
+def test_target_gates_and_connectivity():
+    backend = QCDLBackend(make_solver())
+    target = backend.target
+
+    assert set(target.operation_names) == set(_QCDL_STANDARD_GATE_NAMES) | {"measure"}
+    assert target.num_qubits is None
+    # properties=None instructions are global, i.e. all-to-all
+    assert target.qargs is None
+
+
+def test_target_num_qubits_from_solver():
+    backend = QCDLBackend(make_solver(num_qubits=8))
+    assert backend.target.num_qubits == 8
+
+
+def test_default_options():
+    backend = QCDLBackend(make_solver())
+    assert dict(backend.options) == {
+        "shots": 1024, "time_limit": None, "label": None, "qcdl_pack_target": True,
+    }
+
+
+def test_shots_validated_against_max_shots(monkeypatch):
+    backend = QCDLBackend(make_solver())  # mock solver has max_shots=10000
+    patch_sample_qcdl(monkeypatch, backend.solver, [StubFuture()])
+
+    with pytest.raises(ValueError, match="shots"):
+        backend.run(bell_circuit(), shots=20000)
+
+
+def test_unknown_run_option_rejected():
+    backend = QCDLBackend(make_solver())
+    with pytest.raises(AttributeError, match="num_reads"):
+        backend.run(bell_circuit(), num_reads=100)
+
+
+def test_run_rejects_non_circuit_input():
+    backend = QCDLBackend(make_solver())
+    with pytest.raises(TypeError):
+        backend.run("not a circuit")
+
+
+def test_run_single_circuit(monkeypatch):
+    backend = QCDLBackend(make_solver())
+    calls = patch_sample_qcdl(monkeypatch, backend.solver, [StubFuture()])
+
+    job = backend.run(bell_circuit(), shots=100)
+
+    assert isinstance(job, QCDLJob)
+    assert job.backend() is backend
+    assert len(calls) == 1
+    assert calls[0]["params"] == {"shots": 100}
+    assert calls[0]["label"].startswith(f"qiskit:{job.job_id()}:")
+    assert isinstance(calls[0]["qcdl"], dict)  # the submittable QCDL program
+
+
+def test_run_passes_time_limit_and_label(monkeypatch):
+    backend = QCDLBackend(make_solver())
+    calls = patch_sample_qcdl(monkeypatch, backend.solver, [StubFuture()])
+
+    backend.run(bell_circuit(), time_limit=5, label="my-label")
+
+    assert calls[0]["params"] == {"shots": 1024, "time_limit": 5}
+    assert calls[0]["label"] == "my-label"
+
+
+def test_run_packs_circuits_by_default(monkeypatch):
+    backend = QCDLBackend(make_solver())
+    calls = patch_sample_qcdl(monkeypatch, backend.solver, [StubFuture()])
+
+    backend.run([bell_circuit("bell1"), bell_circuit("bell2")])
+
+    assert len(calls) == 1  # both circuits packed into one QCDL
+
+
+def test_run_without_packing(monkeypatch):
+    backend = QCDLBackend(make_solver())
+    calls = patch_sample_qcdl(monkeypatch, backend.solver, [StubFuture(), StubFuture()])
+
+    backend.run([bell_circuit("bell1"), bell_circuit("bell2")], qcdl_pack_target=False)
+
+    assert len(calls) == 2  # one QCDL per circuit
+
+
+# job status
+
+
+def test_submit_raises():
+    job = QCDLJob(backend=None, job_id="id", futures=[], qcdls=[])
+    with pytest.raises(JobError):
+        job.submit()
+
+
+@pytest.mark.parametrize("future,expected", [
+    (StubFuture(remote_status=None), JobStatus.INITIALIZING),
+    (StubFuture(remote_status="PENDING"), JobStatus.QUEUED),
+    (StubFuture(remote_status="IN_PROGRESS"), JobStatus.RUNNING),
+    (StubFuture(done=True, remote_status="COMPLETED"), JobStatus.DONE),
+    (StubFuture(done=True, remote_status="FAILED",
+                exc=SolverFailureError("failed")), JobStatus.ERROR),
+    (StubFuture(done=True, remote_status="CANCELLED",
+                exc=CanceledFutureError()), JobStatus.CANCELLED),
+    (StubFuture(done=True, remote_status="CANCELLED"), JobStatus.CANCELLED),
+])
+def test_future_status_mapping(future, expected):
+    assert _future_status(future) is expected
+
+
+@pytest.mark.parametrize("statuses,expected", [
+    (["COMPLETED", "COMPLETED"], JobStatus.DONE),
+    (["COMPLETED", "IN_PROGRESS"], JobStatus.RUNNING),
+    (["PENDING", "IN_PROGRESS"], JobStatus.RUNNING),
+    (["PENDING", None], JobStatus.QUEUED),
+    ([None, None], JobStatus.INITIALIZING),
+])
+def test_job_status_aggregation(statuses, expected):
+    futures = [
+        StubFuture(remote_status=status, done=(status == "COMPLETED"))
+        for status in statuses
+    ]
+    job = QCDLJob(backend=None, job_id="id", futures=futures, qcdls=[])
+    assert job.status() is expected
+
+
+def test_job_status_error_takes_precedence():
+    futures = [
+        StubFuture(done=True, remote_status="COMPLETED"),
+        StubFuture(done=True, remote_status="FAILED", exc=SolverFailureError("failed")),
+    ]
+    job = QCDLJob(backend=None, job_id="id", futures=futures, qcdls=[])
+    assert job.status() is JobStatus.ERROR
+
+
+def test_cancel_fans_out():
+    futures = [StubFuture(), StubFuture()]
+    job = QCDLJob(backend=None, job_id="id", futures=futures, qcdls=[])
+    job.cancel()
+    assert all(future.cancel_called for future in futures)
+
+
+# job result
+
+
+def test_result_single_circuit(monkeypatch):
+    backend = QCDLBackend(make_solver())
+    answer = make_answer(4, {"0": (0, ["0", "1", "0", "1"]),
+                             "1": (1, ["0", "1", "0", "1"])}, num_qubits=2)
+    patch_sample_qcdl(monkeypatch, backend.solver, [done_future(answer)])
+
+    circuit = bell_circuit()
+    result = backend.run(circuit).result()
+
+    assert result.success
+    assert result.backend_name == "qcdl_mock_solver"
+    assert result.get_counts(circuit) == {"00": 2, "11": 2}
+    assert result.results[0].shots == 4
+    assert result.results[0].header["name"] == "bell"
+
+
+def test_result_circuits_packed_in_one_qcdl(monkeypatch):
+    backend = QCDLBackend(make_solver())
+    # tags are globally unique across the packed circuits: bell1 -> 0/1, bell2 -> 2/3
+    answer = make_answer(4, {"0": (0, ["0", "1", "0", "1"]),
+                             "1": (1, ["0", "1", "0", "1"]),
+                             "2": (0, ["1", "1", "1", "1"]),
+                             "3": (1, ["1", "1", "1", "1"])}, num_qubits=2)
+    calls = patch_sample_qcdl(monkeypatch, backend.solver, [done_future(answer)])
+
+    result = backend.run([bell_circuit("bell1"), bell_circuit("bell2")]).result()
+
+    assert len(calls) == 1
+    assert [res.header["name"] for res in result.results] == ["bell1", "bell2"]
+    assert result.get_counts("bell1") == {"00": 2, "11": 2}
+    assert result.get_counts("bell2") == {"11": 4}
+
+
+def test_result_multiple_qcdls(monkeypatch):
+    backend = QCDLBackend(make_solver())
+    answer1 = make_answer(2, {"0": (0, ["0", "0"]), "1": (1, ["0", "0"])}, num_qubits=2)
+    answer2 = make_answer(2, {"0": (0, ["1", "1"]), "1": (1, ["1", "1"])}, num_qubits=2)
+    patch_sample_qcdl(
+        monkeypatch, backend.solver, [done_future(answer1), done_future(answer2)]
+    )
+
+    job = backend.run(
+        [bell_circuit("bell1"), bell_circuit("bell2")], qcdl_pack_target=False
+    )
+    result = job.result()
+
+    # experiments follow circuit submission order across QCDLs
+    assert [res.header["name"] for res in result.results] == ["bell1", "bell2"]
+    assert result.get_counts("bell1") == {"00": 2}
+    assert result.get_counts("bell2") == {"11": 2}
+
+
+def test_result_cached(monkeypatch):
+    backend = QCDLBackend(make_solver())
+    answer = make_answer(2, {"0": (0, ["0", "0"]), "1": (1, ["0", "0"])}, num_qubits=2)
+    patch_sample_qcdl(monkeypatch, backend.solver, [done_future(answer)])
+
+    job = backend.run(bell_circuit())
+    assert job.result() is job.result()
+
+
+def test_result_raises_on_failed_problem(monkeypatch):
+    backend = QCDLBackend(make_solver())
+    future = StubFuture(done=True, remote_status="FAILED",
+                        exc=SolverFailureError("solver blew up"))
+    patch_sample_qcdl(monkeypatch, backend.solver, [future])
+
+    job = backend.run(bell_circuit())
+    assert job.status() is JobStatus.ERROR
+    with pytest.raises(JobError, match="solver blew up"):
+        job.result()
+
+
+def test_result_timeout(monkeypatch):
+    backend = QCDLBackend(make_solver())
+    patch_sample_qcdl(monkeypatch, backend.solver, [StubFuture(done=False)])
+
+    job = backend.run(bell_circuit())
+    with pytest.raises(JobTimeoutError):
+        job.result(timeout=0.01)
+
+
+# live tests (skipped unless Leap access is configured)
+
+
+def test_live_bell_circuit():
+    try:
+        with DWaveProvider() as provider:
+            try:
+                backend = provider.get_backend()
+            except QiskitBackendNotFoundError:
+                pytest.skip("no QCDL solver available")
+
+            job = backend.run(bell_circuit(), shots=100)
+            counts = job.result().get_counts()
+    except (ValueError, ConfigFileError, SolverError) as exc:
+        pytest.skip(f"no Leap access configured: {exc}")
+
+    assert sum(counts.values()) == 100
+    assert set(counts) <= {"00", "01", "10", "11"}

--- a/tests/test_leap.py
+++ b/tests/test_leap.py
@@ -39,7 +39,23 @@ from dwave.plugins.qiskit.leap.job import _future_status
 
 
 def make_solver(**kwargs) -> QCDLSolver:
+    # TODO: update the `qcdl_solver_data` mock solver data generator
     kwargs.setdefault("category", "software-gate")
+    kwargs.setdefault("default_noise_model", False)
+    kwargs.setdefault("default_qpu", "DRsim_21qubits")
+    kwargs.setdefault("default_repeat_until_shots_requested", False)
+    kwargs.setdefault("default_shots", 1000)
+    kwargs.setdefault("default_time_limit_s", 2700)
+    kwargs.setdefault("default_transpile", True)
+    kwargs.setdefault("maximum_num_qubits", 21)
+    kwargs.setdefault("maximum_shots", 1000000)
+    kwargs.setdefault("maximum_time_limit_s", 2700)
+    kwargs.setdefault("minimum_shots", 1)
+    kwargs.setdefault("minimum_time_limit_s", 1)
+    kwargs.setdefault("supported_qpu_strings", ["DRsim_17qubits", "DRsim_21qubits"])
+    kwargs.setdefault("parameters", dict(noise_model='', qpu='', repeat_until_shots_requested='',
+                                         shots='', time_limit='', transpile=''))
+
     return QCDLSolver(client=mock.Mock(), data=qcdl_solver_data(**kwargs))
 
 
@@ -215,29 +231,39 @@ def test_target_gates_and_connectivity():
     target = backend.target
 
     assert set(target.operation_names) == set(_QCDL_STANDARD_GATE_NAMES) | {"measure"}
-    assert target.num_qubits is None
+    assert target.num_qubits == 21
     # properties=None instructions are global, i.e. all-to-all
     assert target.qargs is None
 
 
 def test_target_num_qubits_from_solver():
-    backend = QCDLSimulatorBackend(make_solver(num_qubits=8))
+    backend = QCDLSimulatorBackend(make_solver(maximum_num_qubits=8))
     assert backend.target.num_qubits == 8
 
 
+def _get_default_solver_options():
+    return {
+        "shots": 1000, "time_limit": 2700,
+        "noise_model": False, "qpu": "DRsim_21qubits",
+        "transpile": True, "repeat_until_shots_requested": False,
+    }
+
+def _get_default_options():
+    return _get_default_solver_options() | {
+        "label": None, "qcdl_pack_target": True,
+    }
+
 def test_default_options():
     backend = QCDLSimulatorBackend(make_solver())
-    assert dict(backend.options) == {
-        "shots": 1024, "time_limit": None, "label": None, "qcdl_pack_target": True,
-    }
+    assert dict(backend.options) == _get_default_options()
 
 
 def test_shots_validated_against_max_shots(monkeypatch):
-    backend = QCDLSimulatorBackend(make_solver())  # mock solver has max_shots=10000
+    backend = QCDLSimulatorBackend(make_solver())  # mock solver has max_shots=1M
     patch_sample_qcdl(monkeypatch, backend.solver, [StubFuture()])
 
     with pytest.raises(ValueError, match="shots"):
-        backend.run(bell_circuit(), shots=20000)
+        backend.run(bell_circuit(), shots=2000000)
 
 
 def test_unknown_run_option_rejected():
@@ -261,7 +287,7 @@ def test_run_single_circuit(monkeypatch):
     assert isinstance(job, QCDLJob)
     assert job.backend() is backend
     assert len(calls) == 1
-    assert calls[0]["params"] == {"shots": 100}
+    assert calls[0]["params"] == _get_default_solver_options() | {"shots": 100}
     assert calls[0]["label"].startswith(f"qiskit:{job.job_id()}:")
     assert isinstance(calls[0]["qcdl"], dict)  # the submittable QCDL program
 
@@ -272,7 +298,7 @@ def test_run_passes_time_limit_and_label(monkeypatch):
 
     backend.run(bell_circuit(), time_limit=5, label="my-label")
 
-    assert calls[0]["params"] == {"shots": 1024, "time_limit": 5}
+    assert calls[0]["params"] == _get_default_solver_options() | {"time_limit": 5}
     assert calls[0]["label"] == "my-label"
 
 

--- a/tests/test_leap.py
+++ b/tests/test_leap.py
@@ -179,6 +179,32 @@ def test_provider_backends_name_filter():
     assert client.get_solvers.call_args.kwargs["name"] == "some_solver"
 
 
+def test_provider_backends_property_filtering_works():
+    solvers = [
+        make_solver(name="dr17", maximum_num_qubits=17),
+        make_solver(name="dr21", maximum_num_qubits=21),
+    ]
+    client = Client(endpoint='mock', token='mock')
+    client._fetch_solvers = lambda **kwargs: solvers
+
+    with mock.patch("dwave.plugins.qiskit.leap.provider.Client") as client_cls:
+        client_cls.from_config.return_value = client
+
+        # name filter
+        backends = DWaveProvider().backends(name="dr17")
+        assert len(backends) == 1
+        assert backends[0].num_qubits == 17
+
+        # custom property filter
+        backends = DWaveProvider().backends(maximum_num_qubits=21)
+        assert len(backends) == 1
+        assert backends[0].name == "dr21"
+
+        # solver/backend not found
+        backends = DWaveProvider().backends(name="non-existing")
+        assert len(backends) == 0
+
+
 def test_get_backend_raises_when_none_match():
     client = mock.Mock()
     client.get_solvers.return_value = []

--- a/tests/test_leap.py
+++ b/tests/test_leap.py
@@ -18,6 +18,7 @@ import unittest.mock as mock
 
 import pytest
 
+from dwave.cloud import Client
 from dwave.cloud.exceptions import (
     CanceledFutureError,
     ConfigFileError,
@@ -165,6 +166,21 @@ def test_get_backend_requires_single_match(num_solvers):
         client_cls.from_config.return_value = client
         with pytest.raises(QiskitBackendNotFoundError):
             DWaveProvider().get_backend()
+
+
+def test_get_backend_returns_first_of_many():
+    solvers = [
+        make_solver(name="qcdl_solver_old", version="0.1"),
+        make_solver(name="qcdl_solver_new", version="0.2"),
+    ]
+    client = Client(endpoint='mock', token='mock')
+    client._fetch_solvers = lambda **kwargs: solvers
+
+    with mock.patch("dwave.plugins.qiskit.leap.provider.Client") as client_cls:
+        client_cls.from_config.return_value = client
+        backend = DWaveProvider().get_backend()
+
+    assert backend.name == "qcdl_solver_new"
 
 
 def test_provider_context_manager_closes_client():

--- a/tests/test_leap.py
+++ b/tests/test_leap.py
@@ -24,6 +24,7 @@ from dwave.cloud.exceptions import (
     ConfigFileError,
     SolverError,
     SolverFailureError,
+    SolverNotFoundError,
 )
 from dwave.cloud.solver import QCDLSolver
 from dwave.cloud.testing.mocks import qcdl_solver_data
@@ -185,7 +186,12 @@ def test_provider_backends_property_filtering_works():
         make_solver(name="dr21", maximum_num_qubits=21),
     ]
     client = Client(endpoint='mock', token='mock')
-    client._fetch_solvers = lambda **kwargs: solvers
+
+    def _fetch_solvers(**kwargs):
+        if kwargs.pop('name', None) not in ['dr17', 'dr21', None]:
+            raise SolverNotFoundError
+        return solvers
+    client._fetch_solvers = _fetch_solvers
 
     with mock.patch("dwave.plugins.qiskit.leap.provider.Client") as client_cls:
         client_cls.from_config.return_value = client
@@ -200,9 +206,18 @@ def test_provider_backends_property_filtering_works():
         assert len(backends) == 1
         assert backends[0].name == "dr21"
 
+        backend = DWaveProvider().get_backend(maximum_num_qubits=21)
+        assert backend.name == "dr21"
+
         # solver/backend not found
         backends = DWaveProvider().backends(name="non-existing")
         assert len(backends) == 0
+
+        with pytest.raises(QiskitBackendNotFoundError):
+            DWaveProvider().get_backend(name="non-existing")
+
+        with pytest.raises(QiskitBackendNotFoundError):
+            DWaveProvider().get_backend(maximum_num_qubits=100)
 
 
 def test_get_backend_raises_when_none_match():

--- a/tests/test_leap.py
+++ b/tests/test_leap.py
@@ -250,7 +250,7 @@ def _get_default_solver_options():
 
 def _get_default_options():
     return _get_default_solver_options() | {
-        "label": None, "qcdl_pack_target": True,
+        "label": None, "pack_qcdls": True, "qcdl_pack_target": 0.4,
     }
 
 def test_default_options():
@@ -315,7 +315,7 @@ def test_run_without_packing(monkeypatch):
     backend = QCDLSimulatorBackend(make_solver())
     calls = patch_sample_qcdl(monkeypatch, backend.solver, [StubFuture(), StubFuture()])
 
-    backend.run([bell_circuit("bell1"), bell_circuit("bell2")], qcdl_pack_target=False)
+    backend.run([bell_circuit("bell1"), bell_circuit("bell2")], pack_qcdls=False)
 
     assert len(calls) == 2  # one QCDL per circuit
 
@@ -421,7 +421,7 @@ def test_result_multiple_qcdls(monkeypatch):
     )
 
     job = backend.run(
-        [bell_circuit("bell1"), bell_circuit("bell2")], qcdl_pack_target=False
+        [bell_circuit("bell1"), bell_circuit("bell2")], pack_qcdls=False
     )
     result = job.result()
 

--- a/tests/test_leap.py
+++ b/tests/test_leap.py
@@ -470,6 +470,34 @@ def test_result_circuits_packed_in_one_qcdl(monkeypatch):
     assert result.get_counts("bell2") == {"11": 4}
 
 
+def test_result_header_carries_circuit_metadata(monkeypatch):
+    # qiskit-experiments reads each experiment's `header["metadata"]`, along
+    # with `shots` and `meas_level`
+    backend = QCDLSimulatorBackend(make_solver())
+    answer = make_answer(4, {"0": (0, ["0", "1", "0", "1"]),
+                             "1": (1, ["0", "1", "0", "1"]),
+                             "2": (0, ["1", "1", "1", "1"]),
+                             "3": (1, ["1", "1", "1", "1"])}, num_qubits=2)
+    patch_sample_qcdl(monkeypatch, backend.solver, [done_future(answer)])
+
+    bell1 = bell_circuit("bell1")
+    bell1.metadata = {"xval": 0.1, "composite_index": [0]}
+    bell2 = bell_circuit("bell2")   # no metadata set
+
+    result = backend.run([bell1, bell2]).result()
+
+    header = result.results[0].header
+    assert header["name"] == "bell1"
+    assert header["memory_slots"] == 2
+    assert header["creg_sizes"] == [["c", 2]]
+    assert header["metadata"] == {"xval": 0.1, "composite_index": [0]}
+    assert result.results[1].header["metadata"] == {}
+    assert result.results[0].meas_level == MeasLevel.CLASSIFIED
+
+    # circuit metadata lives in the header only, not in the experiment data
+    assert "metadata" not in result.data(0)
+
+
 def test_result_multiple_qcdls(monkeypatch):
     backend = QCDLSimulatorBackend(make_solver())
     answer1 = make_answer(2, {"0": (0, ["0", "0"]), "1": (1, ["0", "0"])}, num_qubits=2)

--- a/tests/test_leap.py
+++ b/tests/test_leap.py
@@ -33,6 +33,7 @@ from dwave.gate.results import YieldHandling
 from qiskit import QuantumCircuit
 from qiskit.providers import JobError, JobStatus, JobTimeoutError
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
+from qiskit.result import MeasLevel
 
 from dwave.plugins.qiskit import DWaveProvider
 from dwave.plugins.qiskit.leap import QCDLJob, QCDLResult, QCDLSimulatorBackend
@@ -313,6 +314,20 @@ def test_unknown_run_option_rejected():
     backend = QCDLSimulatorBackend(make_solver())
     with pytest.raises(AttributeError, match="num_reads"):
         backend.run(bell_circuit(), num_reads=100)
+
+
+def test_extra_run_options(monkeypatch):
+    backend = QCDLSimulatorBackend(make_solver())
+    patch_sample_qcdl(monkeypatch, backend.solver, [StubFuture()])
+
+    with pytest.raises(RuntimeError, match="memory"):
+        backend.run(bell_circuit(), memory=1)
+
+    with pytest.raises(RuntimeError, match="meas_level"):
+        backend.run(bell_circuit(), meas_level=MeasLevel.RAW)
+
+    job = backend.run(bell_circuit(), meas_level=MeasLevel.CLASSIFIED)
+    assert isinstance(job, QCDLJob)
 
 
 def test_run_rejects_non_circuit_input():

--- a/tests/test_leap.py
+++ b/tests/test_leap.py
@@ -33,12 +33,13 @@ from qiskit.providers import JobError, JobStatus, JobTimeoutError
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 
 from dwave.plugins.qiskit import DWaveProvider
-from dwave.plugins.qiskit.leap import QCDLBackend, QCDLJob
+from dwave.plugins.qiskit.leap import QCDLJob, QCDLSimulatorBackend
 from dwave.plugins.qiskit.leap.backend import _QCDL_STANDARD_GATE_NAMES
 from dwave.plugins.qiskit.leap.job import _future_status
 
 
 def make_solver(**kwargs) -> QCDLSolver:
+    kwargs.setdefault("category", "software-gate")
     return QCDLSolver(client=mock.Mock(), data=qcdl_solver_data(**kwargs))
 
 
@@ -137,11 +138,15 @@ def test_provider_lists_qcdl_backends():
     client_cls.from_config.assert_called_once()
     call_kwargs = client_cls.from_config.call_args.kwargs
     assert call_kwargs["client"] == "base"
+    assert call_kwargs["connection_close"] is True
     assert call_kwargs["token"] == "secret"
-    assert client.get_solvers.call_args.kwargs["supported_problem_types__contains"] == "qcdl"
+    solver_filters = client.get_solvers.call_args.kwargs
+    assert solver_filters["supported_problem_types__contains"] == "qcdl"
+    assert solver_filters["category"] == "software-gate"
+    assert solver_filters["order_by"] == "-properties.version"
 
     assert len(backends) == 1
-    assert isinstance(backends[0], QCDLBackend)
+    assert isinstance(backends[0], QCDLSimulatorBackend)
     assert backends[0].name == "qcdl_mock_solver"
     assert backends[0].provider is provider
 
@@ -157,10 +162,9 @@ def test_provider_backends_name_filter():
     assert client.get_solvers.call_args.kwargs["name"] == "some_solver"
 
 
-@pytest.mark.parametrize("num_solvers", [0, 2])
-def test_get_backend_requires_single_match(num_solvers):
+def test_get_backend_raises_when_none_match():
     client = mock.Mock()
-    client.get_solvers.return_value = [make_solver() for _ in range(num_solvers)]
+    client.get_solvers.return_value = []
 
     with mock.patch("dwave.plugins.qiskit.leap.provider.Client") as client_cls:
         client_cls.from_config.return_value = client
@@ -201,8 +205,13 @@ def test_provider_context_manager_closes_client():
 # backend
 
 
+def test_backend_rejects_non_simulator_solver():
+    with pytest.raises(ValueError, match="not a gate-model simulator"):
+        QCDLSimulatorBackend(make_solver(category="hybrid"))
+
+
 def test_target_gates_and_connectivity():
-    backend = QCDLBackend(make_solver())
+    backend = QCDLSimulatorBackend(make_solver())
     target = backend.target
 
     assert set(target.operation_names) == set(_QCDL_STANDARD_GATE_NAMES) | {"measure"}
@@ -212,19 +221,19 @@ def test_target_gates_and_connectivity():
 
 
 def test_target_num_qubits_from_solver():
-    backend = QCDLBackend(make_solver(num_qubits=8))
+    backend = QCDLSimulatorBackend(make_solver(num_qubits=8))
     assert backend.target.num_qubits == 8
 
 
 def test_default_options():
-    backend = QCDLBackend(make_solver())
+    backend = QCDLSimulatorBackend(make_solver())
     assert dict(backend.options) == {
         "shots": 1024, "time_limit": None, "label": None, "qcdl_pack_target": True,
     }
 
 
 def test_shots_validated_against_max_shots(monkeypatch):
-    backend = QCDLBackend(make_solver())  # mock solver has max_shots=10000
+    backend = QCDLSimulatorBackend(make_solver())  # mock solver has max_shots=10000
     patch_sample_qcdl(monkeypatch, backend.solver, [StubFuture()])
 
     with pytest.raises(ValueError, match="shots"):
@@ -232,19 +241,19 @@ def test_shots_validated_against_max_shots(monkeypatch):
 
 
 def test_unknown_run_option_rejected():
-    backend = QCDLBackend(make_solver())
+    backend = QCDLSimulatorBackend(make_solver())
     with pytest.raises(AttributeError, match="num_reads"):
         backend.run(bell_circuit(), num_reads=100)
 
 
 def test_run_rejects_non_circuit_input():
-    backend = QCDLBackend(make_solver())
+    backend = QCDLSimulatorBackend(make_solver())
     with pytest.raises(TypeError):
         backend.run("not a circuit")
 
 
 def test_run_single_circuit(monkeypatch):
-    backend = QCDLBackend(make_solver())
+    backend = QCDLSimulatorBackend(make_solver())
     calls = patch_sample_qcdl(monkeypatch, backend.solver, [StubFuture()])
 
     job = backend.run(bell_circuit(), shots=100)
@@ -258,7 +267,7 @@ def test_run_single_circuit(monkeypatch):
 
 
 def test_run_passes_time_limit_and_label(monkeypatch):
-    backend = QCDLBackend(make_solver())
+    backend = QCDLSimulatorBackend(make_solver())
     calls = patch_sample_qcdl(monkeypatch, backend.solver, [StubFuture()])
 
     backend.run(bell_circuit(), time_limit=5, label="my-label")
@@ -268,7 +277,7 @@ def test_run_passes_time_limit_and_label(monkeypatch):
 
 
 def test_run_packs_circuits_by_default(monkeypatch):
-    backend = QCDLBackend(make_solver())
+    backend = QCDLSimulatorBackend(make_solver())
     calls = patch_sample_qcdl(monkeypatch, backend.solver, [StubFuture()])
 
     backend.run([bell_circuit("bell1"), bell_circuit("bell2")])
@@ -277,7 +286,7 @@ def test_run_packs_circuits_by_default(monkeypatch):
 
 
 def test_run_without_packing(monkeypatch):
-    backend = QCDLBackend(make_solver())
+    backend = QCDLSimulatorBackend(make_solver())
     calls = patch_sample_qcdl(monkeypatch, backend.solver, [StubFuture(), StubFuture()])
 
     backend.run([bell_circuit("bell1"), bell_circuit("bell2")], qcdl_pack_target=False)
@@ -345,7 +354,7 @@ def test_cancel_fans_out():
 
 
 def test_result_single_circuit(monkeypatch):
-    backend = QCDLBackend(make_solver())
+    backend = QCDLSimulatorBackend(make_solver())
     answer = make_answer(4, {"0": (0, ["0", "1", "0", "1"]),
                              "1": (1, ["0", "1", "0", "1"])}, num_qubits=2)
     patch_sample_qcdl(monkeypatch, backend.solver, [done_future(answer)])
@@ -361,7 +370,7 @@ def test_result_single_circuit(monkeypatch):
 
 
 def test_result_circuits_packed_in_one_qcdl(monkeypatch):
-    backend = QCDLBackend(make_solver())
+    backend = QCDLSimulatorBackend(make_solver())
     # tags are globally unique across the packed circuits: bell1 -> 0/1, bell2 -> 2/3
     answer = make_answer(4, {"0": (0, ["0", "1", "0", "1"]),
                              "1": (1, ["0", "1", "0", "1"]),
@@ -378,7 +387,7 @@ def test_result_circuits_packed_in_one_qcdl(monkeypatch):
 
 
 def test_result_multiple_qcdls(monkeypatch):
-    backend = QCDLBackend(make_solver())
+    backend = QCDLSimulatorBackend(make_solver())
     answer1 = make_answer(2, {"0": (0, ["0", "0"]), "1": (1, ["0", "0"])}, num_qubits=2)
     answer2 = make_answer(2, {"0": (0, ["1", "1"]), "1": (1, ["1", "1"])}, num_qubits=2)
     patch_sample_qcdl(
@@ -397,7 +406,7 @@ def test_result_multiple_qcdls(monkeypatch):
 
 
 def test_result_cached(monkeypatch):
-    backend = QCDLBackend(make_solver())
+    backend = QCDLSimulatorBackend(make_solver())
     answer = make_answer(2, {"0": (0, ["0", "0"]), "1": (1, ["0", "0"])}, num_qubits=2)
     patch_sample_qcdl(monkeypatch, backend.solver, [done_future(answer)])
 
@@ -406,7 +415,7 @@ def test_result_cached(monkeypatch):
 
 
 def test_result_raises_on_failed_problem(monkeypatch):
-    backend = QCDLBackend(make_solver())
+    backend = QCDLSimulatorBackend(make_solver())
     future = StubFuture(done=True, remote_status="FAILED",
                         exc=SolverFailureError("solver blew up"))
     patch_sample_qcdl(monkeypatch, backend.solver, [future])
@@ -418,7 +427,7 @@ def test_result_raises_on_failed_problem(monkeypatch):
 
 
 def test_result_timeout(monkeypatch):
-    backend = QCDLBackend(make_solver())
+    backend = QCDLSimulatorBackend(make_solver())
     patch_sample_qcdl(monkeypatch, backend.solver, [StubFuture(done=False)])
 
     job = backend.run(bell_circuit())

--- a/tests/test_leap.py
+++ b/tests/test_leap.py
@@ -27,13 +27,14 @@ from dwave.cloud.exceptions import (
 )
 from dwave.cloud.solver import QCDLSolver
 from dwave.cloud.testing.mocks import qcdl_solver_data
+from dwave.gate.results import YieldHandling
 
 from qiskit import QuantumCircuit
 from qiskit.providers import JobError, JobStatus, JobTimeoutError
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 
 from dwave.plugins.qiskit import DWaveProvider
-from dwave.plugins.qiskit.leap import QCDLJob, QCDLSimulatorBackend
+from dwave.plugins.qiskit.leap import QCDLJob, QCDLResult, QCDLSimulatorBackend
 from dwave.plugins.qiskit.leap.backend import _QCDL_STANDARD_GATE_NAMES
 from dwave.plugins.qiskit.leap.job import _future_status
 
@@ -251,6 +252,7 @@ def _get_default_solver_options():
 def _get_default_options():
     return _get_default_solver_options() | {
         "label": None, "pack_qcdls": True, "qcdl_pack_target": 0.4,
+        "yield_handling": YieldHandling.only_post_selected_counts,
     }
 
 def test_default_options():
@@ -459,6 +461,56 @@ def test_result_timeout(monkeypatch):
     job = backend.run(bell_circuit())
     with pytest.raises(JobTimeoutError):
         job.result(timeout=0.01)
+
+
+def make_splat_answer() -> dict:
+    """An answer where noise_model=True marked one measurement with a splat."""
+    return make_answer(4, {"0": (0, ["0", "1", "*", "1"]),
+                           "1": (1, ["0", "1", "0", "1"])}, num_qubits=2)
+
+
+def test_result_post_selects_splats_by_default(monkeypatch):
+    backend = QCDLSimulatorBackend(make_solver())
+    patch_sample_qcdl(monkeypatch, backend.solver, [done_future(make_splat_answer())])
+
+    result = backend.run(bell_circuit(), noise_model=True).result()
+
+    assert isinstance(result, QCDLResult)
+    assert result.get_counts() == {"00": 1, "11": 2}
+    # the unresolved counts and the yield stay available in the experiment data
+    assert result.data(0)["raw_counts"] == {"00": 1, "11": 2, "0*": 1}
+    assert result.data(0)["post_selection_yield"] == 0.75
+
+
+def test_result_keeps_splats_when_ignored(monkeypatch):
+    backend = QCDLSimulatorBackend(make_solver())
+    patch_sample_qcdl(monkeypatch, backend.solver, [done_future(make_splat_answer())])
+
+    job = backend.run(bell_circuit(), noise_model=True,
+                      yield_handling=YieldHandling.ignore_splats)
+    counts = job.result().get_counts()
+
+    assert counts == {"00": 1, "11": 2, "0*": 1}
+
+
+def test_get_counts_yield_handling_override(monkeypatch):
+    backend = QCDLSimulatorBackend(make_solver())
+    patch_sample_qcdl(monkeypatch, backend.solver, [done_future(make_splat_answer())])
+
+    # yield_handling is also accepted by name
+    result = backend.run(bell_circuit(), noise_model=True,
+                         yield_handling="ignore_splats").result()
+
+    assert result.get_counts() == {"00": 1, "11": 2, "0*": 1}
+    renormalized = result.get_counts(
+        yield_handling=YieldHandling.renormalize_distribution)
+    assert renormalized == {"00": pytest.approx(4 / 3), "11": pytest.approx(8 / 3)}
+
+
+def test_run_rejects_invalid_yield_handling():
+    backend = QCDLSimulatorBackend(make_solver())
+    with pytest.raises(ValueError, match="yield_handling"):
+        backend.run(bell_circuit(), yield_handling="not_a_strategy")
 
 
 # live tests (skipped unless Leap access is configured)


### PR DESCRIPTION
#### Add Qiskit provider for D-Wave Leap QCDL solvers

Adds a Qiskit provider/backend/job stack that runs Qiskit circuits on
D-Wave Leap quantum gate model (QCDL) simulator solvers.

```python
from qiskit import QuantumCircuit
from dwave.plugins.qiskit import DWaveProvider

qc = QuantumCircuit(2, 2, name="bell")
qc.h(0)
qc.cx(0, 1)
qc.measure([0, 1], [0, 1])

with DWaveProvider() as provider:
  backend = provider.get_backend()
  counts = backend.run(qc, shots=1000).result().get_counts()
```


#### AI Generation Disclosure

Used Claude for the initial draft and `yield_handling` support.